### PR TITLE
deps: updated firebase dependencies

### DIFF
--- a/packages/cloud_firestore_odm/CHANGELOG.md
+++ b/packages/cloud_firestore_odm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-dev.85 - 2024-06-09
+
+- Bumped minimum cloud_firestore version to `5.0.0`
+
 ## 1.0.0-dev.84 - 2024-03-04
 
 - Bumped minimum cloud_firestore version to `4.15.0`

--- a/packages/cloud_firestore_odm/example/pubspec.yaml
+++ b/packages/cloud_firestore_odm/example/pubspec.yaml
@@ -5,14 +5,14 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  cloud_firestore: ^4.15.0
-  cloud_firestore_odm: ^1.0.0-dev.84
-  firebase_core: ^2.24.2
+  cloud_firestore: ^5.0.0
+  cloud_firestore_odm: ^1.0.0-dev.85
+  firebase_core: ^3.0.0
   flutter:
     sdk: flutter
   freezed_annotation: ^2.2.0
   json_annotation: ^4.8.1
-  meta: ^1.8.0
+  meta: ^1.12.0
 
 dev_dependencies:
   build_runner: ^2.4.2

--- a/packages/cloud_firestore_odm/pubspec.yaml
+++ b/packages/cloud_firestore_odm/pubspec.yaml
@@ -2,7 +2,7 @@ name: cloud_firestore_odm
 description: An ODM for Firebase Cloud Firestore (cloud_firestore).
 homepage: https://github.com/firebaseextended/firestoreodm-flutter
 repository: https://github.com/firebaseextended/firestoreodm-flutter
-version: 1.0.0-dev.84
+version: 1.0.0-dev.85
 
 false_secrets:
   - example/**
@@ -11,11 +11,11 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  cloud_firestore: ^4.15.0
+  cloud_firestore: ^5.0.0
   flutter:
     sdk: flutter
   json_annotation: ^4.8.1
-  meta: ^1.8.0
+  meta: ^1.12.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/cloud_firestore_odm_generator/CHANGELOG.md
+++ b/packages/cloud_firestore_odm_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-dev.86 - 2024-06-09
+
+- Bumped cloud_firestore_odm dependency to 1.0.0-dev.85
+
 ## 1.0.0-dev.85 - 2024-03-04
 
 - Fixed the ODM incorrectly passing `isNull` to Firestore `where` queries.

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/pubspec.yaml
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/pubspec.yaml
@@ -5,17 +5,17 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  cloud_firestore: ^4.15.0
-  cloud_firestore_odm: ^1.0.0-dev.84
+  cloud_firestore: ^5.0.0
+  cloud_firestore_odm: ^1.0.0-dev.85
   flutter:
     sdk: flutter
   freezed_annotation: ^2.2.0
   json_annotation: ^4.8.1
-  meta: ^1.8.0
+  meta: ^1.12.0
 
 dev_dependencies:
   build_runner: ^2.4.2
-  cloud_firestore_odm_generator: ^1.0.0-dev.84
+  cloud_firestore_odm_generator: ^1.0.0-dev.86
   flutter_test:
     sdk: flutter
   freezed: ^2.3.2

--- a/packages/cloud_firestore_odm_generator/pubspec.yaml
+++ b/packages/cloud_firestore_odm_generator/pubspec.yaml
@@ -2,7 +2,7 @@ name: cloud_firestore_odm_generator
 description: A code generator for cloud_firestore_odm.
 homepage: https://firebase.flutter.dev/docs/firestore/odm
 repository: https://github.com/firebaseextended/firestoreodm-flutter
-version: 1.0.0-dev.85
+version: 1.0.0-dev.86
 
 environment:
   sdk: ">=2.18.0 <4.0.0"
@@ -11,7 +11,7 @@ dependencies:
   analyzer: ">=5.12.0 <7.0.0"
   build: ^2.0.1
   build_config: ^1.0.0
-  cloud_firestore_odm: ^1.0.0-dev.84
+  cloud_firestore_odm: ^1.0.0-dev.85
   collection: ^1.15.0
   freezed_annotation: ">=1.0.0 <3.0.0"
   # Can be removed once this is fixed https://github.com/dart-lang/graphs/issues/86


### PR DESCRIPTION
Updated dependencies to work with cloud_firestore: ^5.0.0 & firebase_core: ^3.0.0

Fixes #21

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR