### PR TITLE
Support field values in `set` methods

### DIFF
--- a/packages/cloud_firestore_odm/CHANGELOG.md
+++ b/packages/cloud_firestore_odm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-dev.88
+
+- **BREAKING**: Removes `set` methods from `FirestoreDocumentReference` to make way for generated methods
+
 ## 1.0.0-dev.87 - 2024-07-08
 
 - **FEAT**: Add batch API ([#12](https://github.com/FirebaseExtended/firestoreodm-flutter/issues/12)). ([4dd8a9a8](https://github.com/FirebaseExtended/firestoreodm-flutter/commit/4dd8a9a893bf6ababa5e9d52de95bacc549ad21b))

--- a/packages/cloud_firestore_odm/example/lib/integration.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration.g.dart
@@ -129,15 +129,49 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    AdvancedJson model, {
+    SetOptions? setOptions,
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    AdvancedJson model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    AdvancedJson model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    String? firstName,
-    FieldValue firstNameFieldValue,
-    String? lastName,
-    FieldValue lastNameFieldValue,
+    Object? firstName = _sentinel,
+    FieldValue? firstNameFieldValue,
+    Object? lastName = _sentinel,
+    FieldValue? lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -145,10 +179,10 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    String? firstName,
-    FieldValue firstNameFieldValue,
-    String? lastName,
-    FieldValue lastNameFieldValue,
+    Object? firstName = _sentinel,
+    FieldValue? firstNameFieldValue,
+    Object? lastName = _sentinel,
+    FieldValue? lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -156,10 +190,10 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    String? firstName,
-    FieldValue firstNameFieldValue,
-    String? lastName,
-    FieldValue lastNameFieldValue,
+    Object? firstName = _sentinel,
+    FieldValue? firstNameFieldValue,
+    Object? lastName = _sentinel,
+    FieldValue? lastNameFieldValue,
   });
 }
 
@@ -189,6 +223,57 @@ class _$AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   @override
   Future<AdvancedJsonDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(AdvancedJsonDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    AdvancedJson model, {
+    SetOptions? setOptions,
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (firstNameFieldValue != null)
+        _$AdvancedJsonFieldMap['firstName']!: firstNameFieldValue,
+      if (lastNameFieldValue != null)
+        _$AdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    AdvancedJson model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (firstNameFieldValue != null)
+        _$AdvancedJsonFieldMap['firstName']!: firstNameFieldValue,
+      if (lastNameFieldValue != null)
+        _$AdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    AdvancedJson model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (firstNameFieldValue != null)
+        _$AdvancedJsonFieldMap['firstName']!: firstNameFieldValue,
+      if (lastNameFieldValue != null)
+        _$AdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -1157,15 +1242,49 @@ abstract class _PrivateAdvancedJsonDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    _PrivateAdvancedJson model, {
+    SetOptions? setOptions,
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    _PrivateAdvancedJson model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    _PrivateAdvancedJson model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    String? firstName,
-    FieldValue firstNameFieldValue,
-    String? lastName,
-    FieldValue lastNameFieldValue,
+    Object? firstName = _sentinel,
+    FieldValue? firstNameFieldValue,
+    Object? lastName = _sentinel,
+    FieldValue? lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -1173,10 +1292,10 @@ abstract class _PrivateAdvancedJsonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    String? firstName,
-    FieldValue firstNameFieldValue,
-    String? lastName,
-    FieldValue lastNameFieldValue,
+    Object? firstName = _sentinel,
+    FieldValue? firstNameFieldValue,
+    Object? lastName = _sentinel,
+    FieldValue? lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -1184,10 +1303,10 @@ abstract class _PrivateAdvancedJsonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    String? firstName,
-    FieldValue firstNameFieldValue,
-    String? lastName,
-    FieldValue lastNameFieldValue,
+    Object? firstName = _sentinel,
+    FieldValue? firstNameFieldValue,
+    Object? lastName = _sentinel,
+    FieldValue? lastNameFieldValue,
   });
 }
 
@@ -1221,6 +1340,57 @@ class _$_PrivateAdvancedJsonDocumentReference
     return transaction
         .get(reference)
         .then(_PrivateAdvancedJsonDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    _PrivateAdvancedJson model, {
+    SetOptions? setOptions,
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (firstNameFieldValue != null)
+        _$PrivateAdvancedJsonFieldMap['firstName']!: firstNameFieldValue,
+      if (lastNameFieldValue != null)
+        _$PrivateAdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    _PrivateAdvancedJson model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (firstNameFieldValue != null)
+        _$PrivateAdvancedJsonFieldMap['firstName']!: firstNameFieldValue,
+      if (lastNameFieldValue != null)
+        _$PrivateAdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    _PrivateAdvancedJson model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (firstNameFieldValue != null)
+        _$PrivateAdvancedJsonFieldMap['firstName']!: firstNameFieldValue,
+      if (lastNameFieldValue != null)
+        _$PrivateAdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/integration.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration.g.dart
@@ -134,6 +134,9 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     AdvancedJson model, {
     SetOptions? setOptions,
@@ -145,6 +148,9 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     AdvancedJson model, {
@@ -156,6 +162,9 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     AdvancedJson model, {
@@ -1247,6 +1256,9 @@ abstract class _PrivateAdvancedJsonDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     _PrivateAdvancedJson model, {
     SetOptions? setOptions,
@@ -1258,6 +1270,9 @@ abstract class _PrivateAdvancedJsonDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     _PrivateAdvancedJson model, {
@@ -1269,6 +1284,9 @@ abstract class _PrivateAdvancedJsonDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     _PrivateAdvancedJson model, {

--- a/packages/cloud_firestore_odm/example/lib/integration.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration.g.dart
@@ -139,7 +139,7 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   /// [model] during serialization.
   Future<void> set(
     AdvancedJson model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue firstNameFieldValue,
     FieldValue lastNameFieldValue,
   });
@@ -154,6 +154,7 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   void transactionSet(
     Transaction transaction,
     AdvancedJson model, {
+    SetOptions? options,
     FieldValue firstNameFieldValue,
     FieldValue lastNameFieldValue,
   });
@@ -168,6 +169,7 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   void batchSet(
     WriteBatch batch,
     AdvancedJson model, {
+    SetOptions? options,
     FieldValue firstNameFieldValue,
     FieldValue lastNameFieldValue,
   });
@@ -236,7 +238,7 @@ class _$AdvancedJsonDocumentReference extends FirestoreDocumentReference<
 
   Future<void> set(
     AdvancedJson model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? firstNameFieldValue,
     FieldValue? lastNameFieldValue,
   }) async {
@@ -248,12 +250,13 @@ class _$AdvancedJsonDocumentReference extends FirestoreDocumentReference<
         _$AdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     AdvancedJson model, {
+    SetOptions? options,
     FieldValue? firstNameFieldValue,
     FieldValue? lastNameFieldValue,
   }) {
@@ -265,12 +268,13 @@ class _$AdvancedJsonDocumentReference extends FirestoreDocumentReference<
         _$AdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     AdvancedJson model, {
+    SetOptions? options,
     FieldValue? firstNameFieldValue,
     FieldValue? lastNameFieldValue,
   }) {
@@ -282,7 +286,7 @@ class _$AdvancedJsonDocumentReference extends FirestoreDocumentReference<
         _$AdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -1261,7 +1265,7 @@ abstract class _PrivateAdvancedJsonDocumentReference
   /// [model] during serialization.
   Future<void> set(
     _PrivateAdvancedJson model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue firstNameFieldValue,
     FieldValue lastNameFieldValue,
   });
@@ -1276,6 +1280,7 @@ abstract class _PrivateAdvancedJsonDocumentReference
   void transactionSet(
     Transaction transaction,
     _PrivateAdvancedJson model, {
+    SetOptions? options,
     FieldValue firstNameFieldValue,
     FieldValue lastNameFieldValue,
   });
@@ -1290,6 +1295,7 @@ abstract class _PrivateAdvancedJsonDocumentReference
   void batchSet(
     WriteBatch batch,
     _PrivateAdvancedJson model, {
+    SetOptions? options,
     FieldValue firstNameFieldValue,
     FieldValue lastNameFieldValue,
   });
@@ -1362,7 +1368,7 @@ class _$_PrivateAdvancedJsonDocumentReference
 
   Future<void> set(
     _PrivateAdvancedJson model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? firstNameFieldValue,
     FieldValue? lastNameFieldValue,
   }) async {
@@ -1374,12 +1380,13 @@ class _$_PrivateAdvancedJsonDocumentReference
         _$PrivateAdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     _PrivateAdvancedJson model, {
+    SetOptions? options,
     FieldValue? firstNameFieldValue,
     FieldValue? lastNameFieldValue,
   }) {
@@ -1391,12 +1398,13 @@ class _$_PrivateAdvancedJsonDocumentReference
         _$PrivateAdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     _PrivateAdvancedJson model, {
+    SetOptions? options,
     FieldValue? firstNameFieldValue,
     FieldValue? lastNameFieldValue,
   }) {
@@ -1408,7 +1416,7 @@ class _$_PrivateAdvancedJsonDocumentReference
         _$PrivateAdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/integration.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration.g.dart
@@ -168,9 +168,9 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? firstName = _sentinel,
+    String? firstName,
     FieldValue? firstNameFieldValue,
-    Object? lastName = _sentinel,
+    String? lastName,
     FieldValue? lastNameFieldValue,
   });
 
@@ -179,9 +179,9 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? firstName = _sentinel,
+    String? firstName,
     FieldValue? firstNameFieldValue,
-    Object? lastName = _sentinel,
+    String? lastName,
     FieldValue? lastNameFieldValue,
   });
 
@@ -190,9 +190,9 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? firstName = _sentinel,
+    String? firstName,
     FieldValue? firstNameFieldValue,
-    Object? lastName = _sentinel,
+    String? lastName,
     FieldValue? lastNameFieldValue,
   });
 }
@@ -1281,9 +1281,9 @@ abstract class _PrivateAdvancedJsonDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? firstName = _sentinel,
+    String? firstName,
     FieldValue? firstNameFieldValue,
-    Object? lastName = _sentinel,
+    String? lastName,
     FieldValue? lastNameFieldValue,
   });
 
@@ -1292,9 +1292,9 @@ abstract class _PrivateAdvancedJsonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? firstName = _sentinel,
+    String? firstName,
     FieldValue? firstNameFieldValue,
-    Object? lastName = _sentinel,
+    String? lastName,
     FieldValue? lastNameFieldValue,
   });
 
@@ -1303,9 +1303,9 @@ abstract class _PrivateAdvancedJsonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? firstName = _sentinel,
+    String? firstName,
     FieldValue? firstNameFieldValue,
-    Object? lastName = _sentinel,
+    String? lastName,
     FieldValue? lastNameFieldValue,
   });
 }

--- a/packages/cloud_firestore_odm/example/lib/integration.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration.g.dart
@@ -136,7 +136,7 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     AdvancedJson model, {
     SetOptions? setOptions,
@@ -150,7 +150,7 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     AdvancedJson model, {
@@ -164,7 +164,7 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     AdvancedJson model, {
@@ -1258,7 +1258,7 @@ abstract class _PrivateAdvancedJsonDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     _PrivateAdvancedJson model, {
     SetOptions? setOptions,
@@ -1272,7 +1272,7 @@ abstract class _PrivateAdvancedJsonDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     _PrivateAdvancedJson model, {
@@ -1286,7 +1286,7 @@ abstract class _PrivateAdvancedJsonDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     _PrivateAdvancedJson model, {

--- a/packages/cloud_firestore_odm/example/lib/integration.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration.g.dart
@@ -137,8 +137,8 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   Future<void> set(
     AdvancedJson model, {
     SetOptions? setOptions,
-    FieldValue? firstNameFieldValue,
-    FieldValue? lastNameFieldValue,
+    FieldValue firstNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -148,8 +148,8 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   void transactionSet(
     Transaction transaction,
     AdvancedJson model, {
-    FieldValue? firstNameFieldValue,
-    FieldValue? lastNameFieldValue,
+    FieldValue firstNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -159,8 +159,8 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   void batchSet(
     WriteBatch batch,
     AdvancedJson model, {
-    FieldValue? firstNameFieldValue,
-    FieldValue? lastNameFieldValue,
+    FieldValue firstNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -169,9 +169,9 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   /// If no document exists yet, the update will fail.
   Future<void> update({
     String? firstName,
-    FieldValue? firstNameFieldValue,
+    FieldValue firstNameFieldValue,
     String? lastName,
-    FieldValue? lastNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -180,9 +180,9 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   void transactionUpdate(
     Transaction transaction, {
     String? firstName,
-    FieldValue? firstNameFieldValue,
+    FieldValue firstNameFieldValue,
     String? lastName,
-    FieldValue? lastNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -191,9 +191,9 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
   void batchUpdate(
     WriteBatch batch, {
     String? firstName,
-    FieldValue? firstNameFieldValue,
+    FieldValue firstNameFieldValue,
     String? lastName,
-    FieldValue? lastNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 }
 
@@ -1250,8 +1250,8 @@ abstract class _PrivateAdvancedJsonDocumentReference
   Future<void> set(
     _PrivateAdvancedJson model, {
     SetOptions? setOptions,
-    FieldValue? firstNameFieldValue,
-    FieldValue? lastNameFieldValue,
+    FieldValue firstNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -1261,8 +1261,8 @@ abstract class _PrivateAdvancedJsonDocumentReference
   void transactionSet(
     Transaction transaction,
     _PrivateAdvancedJson model, {
-    FieldValue? firstNameFieldValue,
-    FieldValue? lastNameFieldValue,
+    FieldValue firstNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -1272,8 +1272,8 @@ abstract class _PrivateAdvancedJsonDocumentReference
   void batchSet(
     WriteBatch batch,
     _PrivateAdvancedJson model, {
-    FieldValue? firstNameFieldValue,
-    FieldValue? lastNameFieldValue,
+    FieldValue firstNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -1282,9 +1282,9 @@ abstract class _PrivateAdvancedJsonDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     String? firstName,
-    FieldValue? firstNameFieldValue,
+    FieldValue firstNameFieldValue,
     String? lastName,
-    FieldValue? lastNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -1293,9 +1293,9 @@ abstract class _PrivateAdvancedJsonDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     String? firstName,
-    FieldValue? firstNameFieldValue,
+    FieldValue firstNameFieldValue,
     String? lastName,
-    FieldValue? lastNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -1304,9 +1304,9 @@ abstract class _PrivateAdvancedJsonDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     String? firstName,
-    FieldValue? firstNameFieldValue,
+    FieldValue firstNameFieldValue,
     String? lastName,
-    FieldValue? lastNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 }
 

--- a/packages/cloud_firestore_odm/example/lib/integration.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration.g.dart
@@ -250,7 +250,11 @@ class _$AdvancedJsonDocumentReference extends FirestoreDocumentReference<
         _$AdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -1380,7 +1384,11 @@ class _$_PrivateAdvancedJsonDocumentReference
         _$PrivateAdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(

--- a/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
@@ -174,15 +174,15 @@ abstract class EnumsDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? id = _sentinel,
+    String id,
     FieldValue? idFieldValue,
-    Object? enumValue = _sentinel,
+    TestEnum enumValue,
     FieldValue? enumValueFieldValue,
-    Object? nullableEnumValue = _sentinel,
+    TestEnum? nullableEnumValue,
     FieldValue? nullableEnumValueFieldValue,
-    Object? enumList = _sentinel,
+    List<TestEnum> enumList,
     FieldValue? enumListFieldValue,
-    Object? nullableEnumList = _sentinel,
+    List<TestEnum>? nullableEnumList,
     FieldValue? nullableEnumListFieldValue,
   });
 
@@ -191,15 +191,15 @@ abstract class EnumsDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? id = _sentinel,
+    String id,
     FieldValue? idFieldValue,
-    Object? enumValue = _sentinel,
+    TestEnum enumValue,
     FieldValue? enumValueFieldValue,
-    Object? nullableEnumValue = _sentinel,
+    TestEnum? nullableEnumValue,
     FieldValue? nullableEnumValueFieldValue,
-    Object? enumList = _sentinel,
+    List<TestEnum> enumList,
     FieldValue? enumListFieldValue,
-    Object? nullableEnumList = _sentinel,
+    List<TestEnum>? nullableEnumList,
     FieldValue? nullableEnumListFieldValue,
   });
 
@@ -208,15 +208,15 @@ abstract class EnumsDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? id = _sentinel,
+    String id,
     FieldValue? idFieldValue,
-    Object? enumValue = _sentinel,
+    TestEnum enumValue,
     FieldValue? enumValueFieldValue,
-    Object? nullableEnumValue = _sentinel,
+    TestEnum? nullableEnumValue,
     FieldValue? nullableEnumValueFieldValue,
-    Object? enumList = _sentinel,
+    List<TestEnum> enumList,
     FieldValue? enumListFieldValue,
-    Object? nullableEnumList = _sentinel,
+    List<TestEnum>? nullableEnumList,
     FieldValue? nullableEnumListFieldValue,
   });
 }

--- a/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
@@ -134,11 +134,11 @@ abstract class EnumsDocumentReference
   Future<void> set(
     Enums model, {
     SetOptions? setOptions,
-    FieldValue? idFieldValue,
-    FieldValue? enumValueFieldValue,
-    FieldValue? nullableEnumValueFieldValue,
-    FieldValue? enumListFieldValue,
-    FieldValue? nullableEnumListFieldValue,
+    FieldValue idFieldValue,
+    FieldValue enumValueFieldValue,
+    FieldValue nullableEnumValueFieldValue,
+    FieldValue enumListFieldValue,
+    FieldValue nullableEnumListFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -148,11 +148,11 @@ abstract class EnumsDocumentReference
   void transactionSet(
     Transaction transaction,
     Enums model, {
-    FieldValue? idFieldValue,
-    FieldValue? enumValueFieldValue,
-    FieldValue? nullableEnumValueFieldValue,
-    FieldValue? enumListFieldValue,
-    FieldValue? nullableEnumListFieldValue,
+    FieldValue idFieldValue,
+    FieldValue enumValueFieldValue,
+    FieldValue nullableEnumValueFieldValue,
+    FieldValue enumListFieldValue,
+    FieldValue nullableEnumListFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -162,11 +162,11 @@ abstract class EnumsDocumentReference
   void batchSet(
     WriteBatch batch,
     Enums model, {
-    FieldValue? idFieldValue,
-    FieldValue? enumValueFieldValue,
-    FieldValue? nullableEnumValueFieldValue,
-    FieldValue? enumListFieldValue,
-    FieldValue? nullableEnumListFieldValue,
+    FieldValue idFieldValue,
+    FieldValue enumValueFieldValue,
+    FieldValue nullableEnumValueFieldValue,
+    FieldValue enumListFieldValue,
+    FieldValue nullableEnumListFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -175,15 +175,15 @@ abstract class EnumsDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     String id,
-    FieldValue? idFieldValue,
+    FieldValue idFieldValue,
     TestEnum enumValue,
-    FieldValue? enumValueFieldValue,
+    FieldValue enumValueFieldValue,
     TestEnum? nullableEnumValue,
-    FieldValue? nullableEnumValueFieldValue,
+    FieldValue nullableEnumValueFieldValue,
     List<TestEnum> enumList,
-    FieldValue? enumListFieldValue,
+    FieldValue enumListFieldValue,
     List<TestEnum>? nullableEnumList,
-    FieldValue? nullableEnumListFieldValue,
+    FieldValue nullableEnumListFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -192,15 +192,15 @@ abstract class EnumsDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     String id,
-    FieldValue? idFieldValue,
+    FieldValue idFieldValue,
     TestEnum enumValue,
-    FieldValue? enumValueFieldValue,
+    FieldValue enumValueFieldValue,
     TestEnum? nullableEnumValue,
-    FieldValue? nullableEnumValueFieldValue,
+    FieldValue nullableEnumValueFieldValue,
     List<TestEnum> enumList,
-    FieldValue? enumListFieldValue,
+    FieldValue enumListFieldValue,
     List<TestEnum>? nullableEnumList,
-    FieldValue? nullableEnumListFieldValue,
+    FieldValue nullableEnumListFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -209,15 +209,15 @@ abstract class EnumsDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     String id,
-    FieldValue? idFieldValue,
+    FieldValue idFieldValue,
     TestEnum enumValue,
-    FieldValue? enumValueFieldValue,
+    FieldValue enumValueFieldValue,
     TestEnum? nullableEnumValue,
-    FieldValue? nullableEnumValueFieldValue,
+    FieldValue nullableEnumValueFieldValue,
     List<TestEnum> enumList,
-    FieldValue? enumListFieldValue,
+    FieldValue enumListFieldValue,
     List<TestEnum>? nullableEnumList,
-    FieldValue? nullableEnumListFieldValue,
+    FieldValue nullableEnumListFieldValue,
   });
 }
 

--- a/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
@@ -136,7 +136,7 @@ abstract class EnumsDocumentReference
   /// [model] during serialization.
   Future<void> set(
     Enums model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue idFieldValue,
     FieldValue enumValueFieldValue,
     FieldValue nullableEnumValueFieldValue,
@@ -154,6 +154,7 @@ abstract class EnumsDocumentReference
   void transactionSet(
     Transaction transaction,
     Enums model, {
+    SetOptions? options,
     FieldValue idFieldValue,
     FieldValue enumValueFieldValue,
     FieldValue nullableEnumValueFieldValue,
@@ -171,6 +172,7 @@ abstract class EnumsDocumentReference
   void batchSet(
     WriteBatch batch,
     Enums model, {
+    SetOptions? options,
     FieldValue idFieldValue,
     FieldValue enumValueFieldValue,
     FieldValue nullableEnumValueFieldValue,
@@ -260,7 +262,7 @@ class _$EnumsDocumentReference
 
   Future<void> set(
     Enums model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? idFieldValue,
     FieldValue? enumValueFieldValue,
     FieldValue? nullableEnumValueFieldValue,
@@ -280,12 +282,13 @@ class _$EnumsDocumentReference
         _$EnumsFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     Enums model, {
+    SetOptions? options,
     FieldValue? idFieldValue,
     FieldValue? enumValueFieldValue,
     FieldValue? nullableEnumValueFieldValue,
@@ -305,12 +308,13 @@ class _$EnumsDocumentReference
         _$EnumsFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     Enums model, {
+    SetOptions? options,
     FieldValue? idFieldValue,
     FieldValue? enumValueFieldValue,
     FieldValue? nullableEnumValueFieldValue,
@@ -330,7 +334,7 @@ class _$EnumsDocumentReference
         _$EnumsFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
@@ -131,6 +131,9 @@ abstract class EnumsDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     Enums model, {
     SetOptions? setOptions,
@@ -145,6 +148,9 @@ abstract class EnumsDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     Enums model, {
@@ -159,6 +165,9 @@ abstract class EnumsDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     Enums model, {

--- a/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
@@ -126,21 +126,64 @@ abstract class EnumsDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    Enums model, {
+    SetOptions? setOptions,
+    FieldValue? idFieldValue,
+    FieldValue? enumValueFieldValue,
+    FieldValue? nullableEnumValueFieldValue,
+    FieldValue? enumListFieldValue,
+    FieldValue? nullableEnumListFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    Enums model, {
+    FieldValue? idFieldValue,
+    FieldValue? enumValueFieldValue,
+    FieldValue? nullableEnumValueFieldValue,
+    FieldValue? enumListFieldValue,
+    FieldValue? nullableEnumListFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    Enums model, {
+    FieldValue? idFieldValue,
+    FieldValue? enumValueFieldValue,
+    FieldValue? nullableEnumValueFieldValue,
+    FieldValue? enumListFieldValue,
+    FieldValue? nullableEnumListFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    String id,
-    FieldValue idFieldValue,
-    TestEnum enumValue,
-    FieldValue enumValueFieldValue,
-    TestEnum? nullableEnumValue,
-    FieldValue nullableEnumValueFieldValue,
-    List<TestEnum> enumList,
-    FieldValue enumListFieldValue,
-    List<TestEnum>? nullableEnumList,
-    FieldValue nullableEnumListFieldValue,
+    Object? id = _sentinel,
+    FieldValue? idFieldValue,
+    Object? enumValue = _sentinel,
+    FieldValue? enumValueFieldValue,
+    Object? nullableEnumValue = _sentinel,
+    FieldValue? nullableEnumValueFieldValue,
+    Object? enumList = _sentinel,
+    FieldValue? enumListFieldValue,
+    Object? nullableEnumList = _sentinel,
+    FieldValue? nullableEnumListFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -148,16 +191,16 @@ abstract class EnumsDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    String id,
-    FieldValue idFieldValue,
-    TestEnum enumValue,
-    FieldValue enumValueFieldValue,
-    TestEnum? nullableEnumValue,
-    FieldValue nullableEnumValueFieldValue,
-    List<TestEnum> enumList,
-    FieldValue enumListFieldValue,
-    List<TestEnum>? nullableEnumList,
-    FieldValue nullableEnumListFieldValue,
+    Object? id = _sentinel,
+    FieldValue? idFieldValue,
+    Object? enumValue = _sentinel,
+    FieldValue? enumValueFieldValue,
+    Object? nullableEnumValue = _sentinel,
+    FieldValue? nullableEnumValueFieldValue,
+    Object? enumList = _sentinel,
+    FieldValue? enumListFieldValue,
+    Object? nullableEnumList = _sentinel,
+    FieldValue? nullableEnumListFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -165,16 +208,16 @@ abstract class EnumsDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    String id,
-    FieldValue idFieldValue,
-    TestEnum enumValue,
-    FieldValue enumValueFieldValue,
-    TestEnum? nullableEnumValue,
-    FieldValue nullableEnumValueFieldValue,
-    List<TestEnum> enumList,
-    FieldValue enumListFieldValue,
-    List<TestEnum>? nullableEnumList,
-    FieldValue nullableEnumListFieldValue,
+    Object? id = _sentinel,
+    FieldValue? idFieldValue,
+    Object? enumValue = _sentinel,
+    FieldValue? enumValueFieldValue,
+    Object? nullableEnumValue = _sentinel,
+    FieldValue? nullableEnumValueFieldValue,
+    Object? enumList = _sentinel,
+    FieldValue? enumListFieldValue,
+    Object? nullableEnumList = _sentinel,
+    FieldValue? nullableEnumListFieldValue,
   });
 }
 
@@ -204,6 +247,81 @@ class _$EnumsDocumentReference
   @override
   Future<EnumsDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(EnumsDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    Enums model, {
+    SetOptions? setOptions,
+    FieldValue? idFieldValue,
+    FieldValue? enumValueFieldValue,
+    FieldValue? nullableEnumValueFieldValue,
+    FieldValue? enumListFieldValue,
+    FieldValue? nullableEnumListFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (idFieldValue != null) _$EnumsFieldMap['id']!: idFieldValue,
+      if (enumValueFieldValue != null)
+        _$EnumsFieldMap['enumValue']!: enumValueFieldValue,
+      if (nullableEnumValueFieldValue != null)
+        _$EnumsFieldMap['nullableEnumValue']!: nullableEnumValueFieldValue,
+      if (enumListFieldValue != null)
+        _$EnumsFieldMap['enumList']!: enumListFieldValue,
+      if (nullableEnumListFieldValue != null)
+        _$EnumsFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    Enums model, {
+    FieldValue? idFieldValue,
+    FieldValue? enumValueFieldValue,
+    FieldValue? nullableEnumValueFieldValue,
+    FieldValue? enumListFieldValue,
+    FieldValue? nullableEnumListFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (idFieldValue != null) _$EnumsFieldMap['id']!: idFieldValue,
+      if (enumValueFieldValue != null)
+        _$EnumsFieldMap['enumValue']!: enumValueFieldValue,
+      if (nullableEnumValueFieldValue != null)
+        _$EnumsFieldMap['nullableEnumValue']!: nullableEnumValueFieldValue,
+      if (enumListFieldValue != null)
+        _$EnumsFieldMap['enumList']!: enumListFieldValue,
+      if (nullableEnumListFieldValue != null)
+        _$EnumsFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    Enums model, {
+    FieldValue? idFieldValue,
+    FieldValue? enumValueFieldValue,
+    FieldValue? nullableEnumValueFieldValue,
+    FieldValue? enumListFieldValue,
+    FieldValue? nullableEnumListFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (idFieldValue != null) _$EnumsFieldMap['id']!: idFieldValue,
+      if (enumValueFieldValue != null)
+        _$EnumsFieldMap['enumValue']!: enumValueFieldValue,
+      if (nullableEnumValueFieldValue != null)
+        _$EnumsFieldMap['nullableEnumValue']!: nullableEnumValueFieldValue,
+      if (enumListFieldValue != null)
+        _$EnumsFieldMap['enumList']!: enumListFieldValue,
+      if (nullableEnumListFieldValue != null)
+        _$EnumsFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
@@ -133,7 +133,7 @@ abstract class EnumsDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     Enums model, {
     SetOptions? setOptions,
@@ -150,7 +150,7 @@ abstract class EnumsDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     Enums model, {
@@ -167,7 +167,7 @@ abstract class EnumsDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     Enums model, {

--- a/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
@@ -282,7 +282,11 @@ class _$EnumsDocumentReference
         _$EnumsFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(

--- a/packages/cloud_firestore_odm/example/lib/integration/freezed.freezed.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/freezed.freezed.dart
@@ -26,8 +26,12 @@ mixin _$Person {
   @JsonKey(includeFromJson: false, includeToJson: false)
   int? get ignored => throw _privateConstructorUsedError;
 
+  /// Serializes this Person to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PersonCopyWith<Person> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -52,6 +56,8 @@ class _$PersonCopyWithImpl<$Res, $Val extends Person>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -97,6 +103,8 @@ class __$$PersonImplCopyWithImpl<$Res>
       _$PersonImpl _value, $Res Function(_$PersonImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -159,11 +167,13 @@ class _$PersonImpl implements _Person {
             (identical(other.ignored, ignored) || other.ignored == ignored));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, firstName, lastName, ignored);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PersonImplCopyWith<_$PersonImpl> get copyWith =>
@@ -194,8 +204,11 @@ abstract class _Person implements Person {
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   int? get ignored;
+
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PersonImplCopyWith<_$PersonImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -208,8 +221,12 @@ PublicRedirected _$PublicRedirectedFromJson(Map<String, dynamic> json) {
 mixin _$PublicRedirected {
   String get value => throw _privateConstructorUsedError;
 
+  /// Serializes this PublicRedirected to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PublicRedirected
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PublicRedirectedCopyWith<PublicRedirected> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -233,6 +250,8 @@ class _$PublicRedirectedCopyWithImpl<$Res, $Val extends PublicRedirected>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PublicRedirected
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -266,6 +285,8 @@ class __$$PublicRedirected2ImplCopyWithImpl<$Res>
       $Res Function(_$PublicRedirected2Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PublicRedirected
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -304,11 +325,13 @@ class _$PublicRedirected2Impl implements PublicRedirected2 {
             (identical(other.value, value) || other.value == value));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, value);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PublicRedirected
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PublicRedirected2ImplCopyWith<_$PublicRedirected2Impl> get copyWith =>
@@ -332,8 +355,11 @@ abstract class PublicRedirected2 implements PublicRedirected {
 
   @override
   String get value;
+
+  /// Create a copy of PublicRedirected
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PublicRedirected2ImplCopyWith<_$PublicRedirected2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
@@ -165,9 +165,9 @@ abstract class PersonDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? firstName = _sentinel,
+    String firstName,
     FieldValue? firstNameFieldValue,
-    Object? lastName = _sentinel,
+    String lastName,
     FieldValue? lastNameFieldValue,
   });
 
@@ -176,9 +176,9 @@ abstract class PersonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? firstName = _sentinel,
+    String firstName,
     FieldValue? firstNameFieldValue,
-    Object? lastName = _sentinel,
+    String lastName,
     FieldValue? lastNameFieldValue,
   });
 
@@ -187,9 +187,9 @@ abstract class PersonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? firstName = _sentinel,
+    String firstName,
     FieldValue? firstNameFieldValue,
-    Object? lastName = _sentinel,
+    String lastName,
     FieldValue? lastNameFieldValue,
   });
 }
@@ -1262,7 +1262,7 @@ abstract class PublicRedirectedDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? value = _sentinel,
+    String value,
     FieldValue? valueFieldValue,
   });
 
@@ -1271,7 +1271,7 @@ abstract class PublicRedirectedDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? value = _sentinel,
+    String value,
     FieldValue? valueFieldValue,
   });
 
@@ -1280,7 +1280,7 @@ abstract class PublicRedirectedDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? value = _sentinel,
+    String value,
     FieldValue? valueFieldValue,
   });
 }

--- a/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
@@ -247,7 +247,11 @@ class _$PersonDocumentReference
         _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -1349,7 +1353,11 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
         _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(

--- a/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
@@ -131,6 +131,9 @@ abstract class PersonDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     Person model, {
     SetOptions? setOptions,
@@ -142,6 +145,9 @@ abstract class PersonDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     Person model, {
@@ -153,6 +159,9 @@ abstract class PersonDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     Person model, {
@@ -1231,6 +1240,9 @@ abstract class PublicRedirectedDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     PublicRedirected model, {
     SetOptions? setOptions,
@@ -1241,6 +1253,9 @@ abstract class PublicRedirectedDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     PublicRedirected model, {
@@ -1251,6 +1266,9 @@ abstract class PublicRedirectedDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     PublicRedirected model, {

--- a/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
@@ -126,15 +126,49 @@ abstract class PersonDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    Person model, {
+    SetOptions? setOptions,
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    Person model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    Person model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    String firstName,
-    FieldValue firstNameFieldValue,
-    String lastName,
-    FieldValue lastNameFieldValue,
+    Object? firstName = _sentinel,
+    FieldValue? firstNameFieldValue,
+    Object? lastName = _sentinel,
+    FieldValue? lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -142,10 +176,10 @@ abstract class PersonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    String firstName,
-    FieldValue firstNameFieldValue,
-    String lastName,
-    FieldValue lastNameFieldValue,
+    Object? firstName = _sentinel,
+    FieldValue? firstNameFieldValue,
+    Object? lastName = _sentinel,
+    FieldValue? lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -153,10 +187,10 @@ abstract class PersonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    String firstName,
-    FieldValue firstNameFieldValue,
-    String lastName,
-    FieldValue lastNameFieldValue,
+    Object? firstName = _sentinel,
+    FieldValue? firstNameFieldValue,
+    Object? lastName = _sentinel,
+    FieldValue? lastNameFieldValue,
   });
 }
 
@@ -186,6 +220,57 @@ class _$PersonDocumentReference
   @override
   Future<PersonDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(PersonDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    Person model, {
+    SetOptions? setOptions,
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (firstNameFieldValue != null)
+        _$$PersonImplFieldMap['firstName']!: firstNameFieldValue,
+      if (lastNameFieldValue != null)
+        _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    Person model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (firstNameFieldValue != null)
+        _$$PersonImplFieldMap['firstName']!: firstNameFieldValue,
+      if (lastNameFieldValue != null)
+        _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    Person model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (firstNameFieldValue != null)
+        _$$PersonImplFieldMap['firstName']!: firstNameFieldValue,
+      if (lastNameFieldValue != null)
+        _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -1141,13 +1226,44 @@ abstract class PublicRedirectedDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    PublicRedirected model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    PublicRedirected model, {
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    PublicRedirected model, {
+    FieldValue? valueFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    String value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -1155,8 +1271,8 @@ abstract class PublicRedirectedDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    String value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -1164,8 +1280,8 @@ abstract class PublicRedirectedDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    String value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 }
 
@@ -1196,6 +1312,48 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
   Future<PublicRedirectedDocumentSnapshot> transactionGet(
       Transaction transaction) {
     return transaction.get(reference).then(PublicRedirectedDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    PublicRedirected model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    PublicRedirected model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    PublicRedirected model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
@@ -133,7 +133,7 @@ abstract class PersonDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     Person model, {
     SetOptions? setOptions,
@@ -147,7 +147,7 @@ abstract class PersonDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     Person model, {
@@ -161,7 +161,7 @@ abstract class PersonDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     Person model, {
@@ -1242,7 +1242,7 @@ abstract class PublicRedirectedDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     PublicRedirected model, {
     SetOptions? setOptions,
@@ -1255,7 +1255,7 @@ abstract class PublicRedirectedDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     PublicRedirected model, {
@@ -1268,7 +1268,7 @@ abstract class PublicRedirectedDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     PublicRedirected model, {

--- a/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
@@ -136,7 +136,7 @@ abstract class PersonDocumentReference
   /// [model] during serialization.
   Future<void> set(
     Person model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue firstNameFieldValue,
     FieldValue lastNameFieldValue,
   });
@@ -151,6 +151,7 @@ abstract class PersonDocumentReference
   void transactionSet(
     Transaction transaction,
     Person model, {
+    SetOptions? options,
     FieldValue firstNameFieldValue,
     FieldValue lastNameFieldValue,
   });
@@ -165,6 +166,7 @@ abstract class PersonDocumentReference
   void batchSet(
     WriteBatch batch,
     Person model, {
+    SetOptions? options,
     FieldValue firstNameFieldValue,
     FieldValue lastNameFieldValue,
   });
@@ -233,7 +235,7 @@ class _$PersonDocumentReference
 
   Future<void> set(
     Person model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? firstNameFieldValue,
     FieldValue? lastNameFieldValue,
   }) async {
@@ -245,12 +247,13 @@ class _$PersonDocumentReference
         _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     Person model, {
+    SetOptions? options,
     FieldValue? firstNameFieldValue,
     FieldValue? lastNameFieldValue,
   }) {
@@ -262,12 +265,13 @@ class _$PersonDocumentReference
         _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     Person model, {
+    SetOptions? options,
     FieldValue? firstNameFieldValue,
     FieldValue? lastNameFieldValue,
   }) {
@@ -279,7 +283,7 @@ class _$PersonDocumentReference
         _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -1245,7 +1249,7 @@ abstract class PublicRedirectedDocumentReference
   /// [model] during serialization.
   Future<void> set(
     PublicRedirected model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -1259,6 +1263,7 @@ abstract class PublicRedirectedDocumentReference
   void transactionSet(
     Transaction transaction,
     PublicRedirected model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -1272,6 +1277,7 @@ abstract class PublicRedirectedDocumentReference
   void batchSet(
     WriteBatch batch,
     PublicRedirected model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -1334,7 +1340,7 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
 
   Future<void> set(
     PublicRedirected model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) async {
     final json = {
@@ -1343,12 +1349,13 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
         _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     PublicRedirected model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -1357,12 +1364,13 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
         _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     PublicRedirected model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -1371,7 +1379,7 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
         _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
@@ -134,8 +134,8 @@ abstract class PersonDocumentReference
   Future<void> set(
     Person model, {
     SetOptions? setOptions,
-    FieldValue? firstNameFieldValue,
-    FieldValue? lastNameFieldValue,
+    FieldValue firstNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -145,8 +145,8 @@ abstract class PersonDocumentReference
   void transactionSet(
     Transaction transaction,
     Person model, {
-    FieldValue? firstNameFieldValue,
-    FieldValue? lastNameFieldValue,
+    FieldValue firstNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -156,8 +156,8 @@ abstract class PersonDocumentReference
   void batchSet(
     WriteBatch batch,
     Person model, {
-    FieldValue? firstNameFieldValue,
-    FieldValue? lastNameFieldValue,
+    FieldValue firstNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -166,9 +166,9 @@ abstract class PersonDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     String firstName,
-    FieldValue? firstNameFieldValue,
+    FieldValue firstNameFieldValue,
     String lastName,
-    FieldValue? lastNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -177,9 +177,9 @@ abstract class PersonDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     String firstName,
-    FieldValue? firstNameFieldValue,
+    FieldValue firstNameFieldValue,
     String lastName,
-    FieldValue? lastNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -188,9 +188,9 @@ abstract class PersonDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     String firstName,
-    FieldValue? firstNameFieldValue,
+    FieldValue firstNameFieldValue,
     String lastName,
-    FieldValue? lastNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 }
 
@@ -1234,7 +1234,7 @@ abstract class PublicRedirectedDocumentReference
   Future<void> set(
     PublicRedirected model, {
     SetOptions? setOptions,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -1244,7 +1244,7 @@ abstract class PublicRedirectedDocumentReference
   void transactionSet(
     Transaction transaction,
     PublicRedirected model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -1254,7 +1254,7 @@ abstract class PublicRedirectedDocumentReference
   void batchSet(
     WriteBatch batch,
     PublicRedirected model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -1263,7 +1263,7 @@ abstract class PublicRedirectedDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     String value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -1272,7 +1272,7 @@ abstract class PublicRedirectedDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     String value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -1281,7 +1281,7 @@ abstract class PublicRedirectedDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     String value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 }
 

--- a/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
@@ -152,7 +152,7 @@ abstract class ConflictDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     Conflict model, {
     SetOptions? setOptions,
@@ -165,7 +165,7 @@ abstract class ConflictDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     Conflict model, {
@@ -178,7 +178,7 @@ abstract class ConflictDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     Conflict model, {

--- a/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
@@ -181,7 +181,7 @@ abstract class ConflictDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? number = _sentinel,
+    num number,
     FieldValue? numberFieldValue,
   });
 
@@ -190,7 +190,7 @@ abstract class ConflictDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? number = _sentinel,
+    num number,
     FieldValue? numberFieldValue,
   });
 
@@ -199,7 +199,7 @@ abstract class ConflictDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? number = _sentinel,
+    num number,
     FieldValue? numberFieldValue,
   });
 }

--- a/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
@@ -145,13 +145,44 @@ abstract class ConflictDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    Conflict model, {
+    SetOptions? setOptions,
+    FieldValue? numberFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    Conflict model, {
+    FieldValue? numberFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    Conflict model, {
+    FieldValue? numberFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    num number,
-    FieldValue numberFieldValue,
+    Object? number = _sentinel,
+    FieldValue? numberFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -159,8 +190,8 @@ abstract class ConflictDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    num number,
-    FieldValue numberFieldValue,
+    Object? number = _sentinel,
+    FieldValue? numberFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -168,8 +199,8 @@ abstract class ConflictDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    num number,
-    FieldValue numberFieldValue,
+    Object? number = _sentinel,
+    FieldValue? numberFieldValue,
   });
 }
 
@@ -199,6 +230,48 @@ class _$ConflictDocumentReference
   @override
   Future<ConflictDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(ConflictDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    Conflict model, {
+    SetOptions? setOptions,
+    FieldValue? numberFieldValue,
+  }) async {
+    final json = {
+      ..._$ConflictToJson(model),
+      if (numberFieldValue != null)
+        _$ConflictFieldMap['number']!: numberFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    Conflict model, {
+    FieldValue? numberFieldValue,
+  }) {
+    final json = {
+      ..._$ConflictToJson(model),
+      if (numberFieldValue != null)
+        _$ConflictFieldMap['number']!: numberFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    Conflict model, {
+    FieldValue? numberFieldValue,
+  }) {
+    final json = {
+      ..._$ConflictToJson(model),
+      if (numberFieldValue != null)
+        _$ConflictFieldMap['number']!: numberFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
@@ -155,7 +155,7 @@ abstract class ConflictDocumentReference
   /// [model] during serialization.
   Future<void> set(
     Conflict model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue numberFieldValue,
   });
 
@@ -169,6 +169,7 @@ abstract class ConflictDocumentReference
   void transactionSet(
     Transaction transaction,
     Conflict model, {
+    SetOptions? options,
     FieldValue numberFieldValue,
   });
 
@@ -182,6 +183,7 @@ abstract class ConflictDocumentReference
   void batchSet(
     WriteBatch batch,
     Conflict model, {
+    SetOptions? options,
     FieldValue numberFieldValue,
   });
 
@@ -243,7 +245,7 @@ class _$ConflictDocumentReference
 
   Future<void> set(
     Conflict model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? numberFieldValue,
   }) async {
     final json = {
@@ -252,12 +254,13 @@ class _$ConflictDocumentReference
         _$ConflictFieldMap['number']!: numberFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     Conflict model, {
+    SetOptions? options,
     FieldValue? numberFieldValue,
   }) {
     final json = {
@@ -266,12 +269,13 @@ class _$ConflictDocumentReference
         _$ConflictFieldMap['number']!: numberFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     Conflict model, {
+    SetOptions? options,
     FieldValue? numberFieldValue,
   }) {
     final json = {
@@ -280,7 +284,7 @@ class _$ConflictDocumentReference
         _$ConflictFieldMap['number']!: numberFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
@@ -153,7 +153,7 @@ abstract class ConflictDocumentReference
   Future<void> set(
     Conflict model, {
     SetOptions? setOptions,
-    FieldValue? numberFieldValue,
+    FieldValue numberFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -163,7 +163,7 @@ abstract class ConflictDocumentReference
   void transactionSet(
     Transaction transaction,
     Conflict model, {
-    FieldValue? numberFieldValue,
+    FieldValue numberFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -173,7 +173,7 @@ abstract class ConflictDocumentReference
   void batchSet(
     WriteBatch batch,
     Conflict model, {
-    FieldValue? numberFieldValue,
+    FieldValue numberFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -182,7 +182,7 @@ abstract class ConflictDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     num number,
-    FieldValue? numberFieldValue,
+    FieldValue numberFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -191,7 +191,7 @@ abstract class ConflictDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     num number,
-    FieldValue? numberFieldValue,
+    FieldValue numberFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -200,7 +200,7 @@ abstract class ConflictDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     num number,
-    FieldValue? numberFieldValue,
+    FieldValue numberFieldValue,
   });
 }
 

--- a/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
@@ -254,7 +254,11 @@ class _$ConflictDocumentReference
         _$ConflictFieldMap['number']!: numberFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(

--- a/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
@@ -150,6 +150,9 @@ abstract class ConflictDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     Conflict model, {
     SetOptions? setOptions,
@@ -160,6 +163,9 @@ abstract class ConflictDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     Conflict model, {
@@ -170,6 +176,9 @@ abstract class ConflictDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     Conflict model, {

--- a/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
@@ -167,7 +167,7 @@ abstract class DurationQueryDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? duration = _sentinel,
+    Duration duration,
     FieldValue? durationFieldValue,
   });
 
@@ -176,7 +176,7 @@ abstract class DurationQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? duration = _sentinel,
+    Duration duration,
     FieldValue? durationFieldValue,
   });
 
@@ -185,7 +185,7 @@ abstract class DurationQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? duration = _sentinel,
+    Duration duration,
     FieldValue? durationFieldValue,
   });
 }
@@ -1080,7 +1080,7 @@ abstract class DateTimeQueryDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? time = _sentinel,
+    DateTime time,
     FieldValue? timeFieldValue,
   });
 
@@ -1089,7 +1089,7 @@ abstract class DateTimeQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? time = _sentinel,
+    DateTime time,
     FieldValue? timeFieldValue,
   });
 
@@ -1098,7 +1098,7 @@ abstract class DateTimeQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? time = _sentinel,
+    DateTime time,
     FieldValue? timeFieldValue,
   });
 }
@@ -1995,7 +1995,7 @@ abstract class TimestampQueryDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? time = _sentinel,
+    Timestamp time,
     FieldValue? timeFieldValue,
   });
 
@@ -2004,7 +2004,7 @@ abstract class TimestampQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? time = _sentinel,
+    Timestamp time,
     FieldValue? timeFieldValue,
   });
 
@@ -2013,7 +2013,7 @@ abstract class TimestampQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? time = _sentinel,
+    Timestamp time,
     FieldValue? timeFieldValue,
   });
 }
@@ -2911,7 +2911,7 @@ abstract class GeoPointQueryDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? point = _sentinel,
+    GeoPoint point,
     FieldValue? pointFieldValue,
   });
 
@@ -2920,7 +2920,7 @@ abstract class GeoPointQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? point = _sentinel,
+    GeoPoint point,
     FieldValue? pointFieldValue,
   });
 
@@ -2929,7 +2929,7 @@ abstract class GeoPointQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? point = _sentinel,
+    GeoPoint point,
     FieldValue? pointFieldValue,
   });
 }
@@ -3829,7 +3829,7 @@ abstract class DocumentReferenceQueryDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? ref = _sentinel,
+    DocumentReference<Map<String, dynamic>> ref,
     FieldValue? refFieldValue,
   });
 
@@ -3838,7 +3838,7 @@ abstract class DocumentReferenceQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? ref = _sentinel,
+    DocumentReference<Map<String, dynamic>> ref,
     FieldValue? refFieldValue,
   });
 
@@ -3847,7 +3847,7 @@ abstract class DocumentReferenceQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? ref = _sentinel,
+    DocumentReference<Map<String, dynamic>> ref,
     FieldValue? refFieldValue,
   });
 }

--- a/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
@@ -241,7 +241,11 @@ class _$DurationQueryDocumentReference extends FirestoreDocumentReference<
         _$DurationQueryFieldMap['duration']!: durationFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -1167,7 +1171,11 @@ class _$DateTimeQueryDocumentReference extends FirestoreDocumentReference<
         _$DateTimeQueryFieldMap['time']!: timeFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -2095,7 +2103,11 @@ class _$TimestampQueryDocumentReference extends FirestoreDocumentReference<
         _$TimestampQueryFieldMap['time']!: timeFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -3024,7 +3036,11 @@ class _$GeoPointQueryDocumentReference extends FirestoreDocumentReference<
         _$GeoPointQueryFieldMap['point']!: pointFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -3960,7 +3976,11 @@ class _$DocumentReferenceQueryDocumentReference
         _$DocumentReferenceQueryFieldMap['ref']!: refFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(

--- a/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
@@ -139,7 +139,7 @@ abstract class DurationQueryDocumentReference
   Future<void> set(
     DurationQuery model, {
     SetOptions? setOptions,
-    FieldValue? durationFieldValue,
+    FieldValue durationFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -149,7 +149,7 @@ abstract class DurationQueryDocumentReference
   void transactionSet(
     Transaction transaction,
     DurationQuery model, {
-    FieldValue? durationFieldValue,
+    FieldValue durationFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -159,7 +159,7 @@ abstract class DurationQueryDocumentReference
   void batchSet(
     WriteBatch batch,
     DurationQuery model, {
-    FieldValue? durationFieldValue,
+    FieldValue durationFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -168,7 +168,7 @@ abstract class DurationQueryDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     Duration duration,
-    FieldValue? durationFieldValue,
+    FieldValue durationFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -177,7 +177,7 @@ abstract class DurationQueryDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     Duration duration,
-    FieldValue? durationFieldValue,
+    FieldValue durationFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -186,7 +186,7 @@ abstract class DurationQueryDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     Duration duration,
-    FieldValue? durationFieldValue,
+    FieldValue durationFieldValue,
   });
 }
 
@@ -1052,7 +1052,7 @@ abstract class DateTimeQueryDocumentReference
   Future<void> set(
     DateTimeQuery model, {
     SetOptions? setOptions,
-    FieldValue? timeFieldValue,
+    FieldValue timeFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -1062,7 +1062,7 @@ abstract class DateTimeQueryDocumentReference
   void transactionSet(
     Transaction transaction,
     DateTimeQuery model, {
-    FieldValue? timeFieldValue,
+    FieldValue timeFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -1072,7 +1072,7 @@ abstract class DateTimeQueryDocumentReference
   void batchSet(
     WriteBatch batch,
     DateTimeQuery model, {
-    FieldValue? timeFieldValue,
+    FieldValue timeFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -1081,7 +1081,7 @@ abstract class DateTimeQueryDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     DateTime time,
-    FieldValue? timeFieldValue,
+    FieldValue timeFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -1090,7 +1090,7 @@ abstract class DateTimeQueryDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     DateTime time,
-    FieldValue? timeFieldValue,
+    FieldValue timeFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -1099,7 +1099,7 @@ abstract class DateTimeQueryDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     DateTime time,
-    FieldValue? timeFieldValue,
+    FieldValue timeFieldValue,
   });
 }
 
@@ -1967,7 +1967,7 @@ abstract class TimestampQueryDocumentReference
   Future<void> set(
     TimestampQuery model, {
     SetOptions? setOptions,
-    FieldValue? timeFieldValue,
+    FieldValue timeFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -1977,7 +1977,7 @@ abstract class TimestampQueryDocumentReference
   void transactionSet(
     Transaction transaction,
     TimestampQuery model, {
-    FieldValue? timeFieldValue,
+    FieldValue timeFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -1987,7 +1987,7 @@ abstract class TimestampQueryDocumentReference
   void batchSet(
     WriteBatch batch,
     TimestampQuery model, {
-    FieldValue? timeFieldValue,
+    FieldValue timeFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -1996,7 +1996,7 @@ abstract class TimestampQueryDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     Timestamp time,
-    FieldValue? timeFieldValue,
+    FieldValue timeFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -2005,7 +2005,7 @@ abstract class TimestampQueryDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     Timestamp time,
-    FieldValue? timeFieldValue,
+    FieldValue timeFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -2014,7 +2014,7 @@ abstract class TimestampQueryDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     Timestamp time,
-    FieldValue? timeFieldValue,
+    FieldValue timeFieldValue,
   });
 }
 
@@ -2883,7 +2883,7 @@ abstract class GeoPointQueryDocumentReference
   Future<void> set(
     GeoPointQuery model, {
     SetOptions? setOptions,
-    FieldValue? pointFieldValue,
+    FieldValue pointFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -2893,7 +2893,7 @@ abstract class GeoPointQueryDocumentReference
   void transactionSet(
     Transaction transaction,
     GeoPointQuery model, {
-    FieldValue? pointFieldValue,
+    FieldValue pointFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -2903,7 +2903,7 @@ abstract class GeoPointQueryDocumentReference
   void batchSet(
     WriteBatch batch,
     GeoPointQuery model, {
-    FieldValue? pointFieldValue,
+    FieldValue pointFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -2912,7 +2912,7 @@ abstract class GeoPointQueryDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     GeoPoint point,
-    FieldValue? pointFieldValue,
+    FieldValue pointFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -2921,7 +2921,7 @@ abstract class GeoPointQueryDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     GeoPoint point,
-    FieldValue? pointFieldValue,
+    FieldValue pointFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -2930,7 +2930,7 @@ abstract class GeoPointQueryDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     GeoPoint point,
-    FieldValue? pointFieldValue,
+    FieldValue pointFieldValue,
   });
 }
 
@@ -3801,7 +3801,7 @@ abstract class DocumentReferenceQueryDocumentReference
   Future<void> set(
     DocumentReferenceQuery model, {
     SetOptions? setOptions,
-    FieldValue? refFieldValue,
+    FieldValue refFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -3811,7 +3811,7 @@ abstract class DocumentReferenceQueryDocumentReference
   void transactionSet(
     Transaction transaction,
     DocumentReferenceQuery model, {
-    FieldValue? refFieldValue,
+    FieldValue refFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -3821,7 +3821,7 @@ abstract class DocumentReferenceQueryDocumentReference
   void batchSet(
     WriteBatch batch,
     DocumentReferenceQuery model, {
-    FieldValue? refFieldValue,
+    FieldValue refFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -3830,7 +3830,7 @@ abstract class DocumentReferenceQueryDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     DocumentReference<Map<String, dynamic>> ref,
-    FieldValue? refFieldValue,
+    FieldValue refFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -3839,7 +3839,7 @@ abstract class DocumentReferenceQueryDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     DocumentReference<Map<String, dynamic>> ref,
-    FieldValue? refFieldValue,
+    FieldValue refFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -3848,7 +3848,7 @@ abstract class DocumentReferenceQueryDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     DocumentReference<Map<String, dynamic>> ref,
-    FieldValue? refFieldValue,
+    FieldValue refFieldValue,
   });
 }
 

--- a/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
@@ -141,7 +141,7 @@ abstract class DurationQueryDocumentReference
   /// [model] during serialization.
   Future<void> set(
     DurationQuery model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue durationFieldValue,
   });
 
@@ -155,6 +155,7 @@ abstract class DurationQueryDocumentReference
   void transactionSet(
     Transaction transaction,
     DurationQuery model, {
+    SetOptions? options,
     FieldValue durationFieldValue,
   });
 
@@ -168,6 +169,7 @@ abstract class DurationQueryDocumentReference
   void batchSet(
     WriteBatch batch,
     DurationQuery model, {
+    SetOptions? options,
     FieldValue durationFieldValue,
   });
 
@@ -230,7 +232,7 @@ class _$DurationQueryDocumentReference extends FirestoreDocumentReference<
 
   Future<void> set(
     DurationQuery model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? durationFieldValue,
   }) async {
     final json = {
@@ -239,12 +241,13 @@ class _$DurationQueryDocumentReference extends FirestoreDocumentReference<
         _$DurationQueryFieldMap['duration']!: durationFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     DurationQuery model, {
+    SetOptions? options,
     FieldValue? durationFieldValue,
   }) {
     final json = {
@@ -253,12 +256,13 @@ class _$DurationQueryDocumentReference extends FirestoreDocumentReference<
         _$DurationQueryFieldMap['duration']!: durationFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     DurationQuery model, {
+    SetOptions? options,
     FieldValue? durationFieldValue,
   }) {
     final json = {
@@ -267,7 +271,7 @@ class _$DurationQueryDocumentReference extends FirestoreDocumentReference<
         _$DurationQueryFieldMap['duration']!: durationFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -1063,7 +1067,7 @@ abstract class DateTimeQueryDocumentReference
   /// [model] during serialization.
   Future<void> set(
     DateTimeQuery model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue timeFieldValue,
   });
 
@@ -1077,6 +1081,7 @@ abstract class DateTimeQueryDocumentReference
   void transactionSet(
     Transaction transaction,
     DateTimeQuery model, {
+    SetOptions? options,
     FieldValue timeFieldValue,
   });
 
@@ -1090,6 +1095,7 @@ abstract class DateTimeQueryDocumentReference
   void batchSet(
     WriteBatch batch,
     DateTimeQuery model, {
+    SetOptions? options,
     FieldValue timeFieldValue,
   });
 
@@ -1152,7 +1158,7 @@ class _$DateTimeQueryDocumentReference extends FirestoreDocumentReference<
 
   Future<void> set(
     DateTimeQuery model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? timeFieldValue,
   }) async {
     final json = {
@@ -1161,12 +1167,13 @@ class _$DateTimeQueryDocumentReference extends FirestoreDocumentReference<
         _$DateTimeQueryFieldMap['time']!: timeFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     DateTimeQuery model, {
+    SetOptions? options,
     FieldValue? timeFieldValue,
   }) {
     final json = {
@@ -1175,12 +1182,13 @@ class _$DateTimeQueryDocumentReference extends FirestoreDocumentReference<
         _$DateTimeQueryFieldMap['time']!: timeFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     DateTimeQuery model, {
+    SetOptions? options,
     FieldValue? timeFieldValue,
   }) {
     final json = {
@@ -1189,7 +1197,7 @@ class _$DateTimeQueryDocumentReference extends FirestoreDocumentReference<
         _$DateTimeQueryFieldMap['time']!: timeFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -1987,7 +1995,7 @@ abstract class TimestampQueryDocumentReference
   /// [model] during serialization.
   Future<void> set(
     TimestampQuery model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue timeFieldValue,
   });
 
@@ -2001,6 +2009,7 @@ abstract class TimestampQueryDocumentReference
   void transactionSet(
     Transaction transaction,
     TimestampQuery model, {
+    SetOptions? options,
     FieldValue timeFieldValue,
   });
 
@@ -2014,6 +2023,7 @@ abstract class TimestampQueryDocumentReference
   void batchSet(
     WriteBatch batch,
     TimestampQuery model, {
+    SetOptions? options,
     FieldValue timeFieldValue,
   });
 
@@ -2076,7 +2086,7 @@ class _$TimestampQueryDocumentReference extends FirestoreDocumentReference<
 
   Future<void> set(
     TimestampQuery model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? timeFieldValue,
   }) async {
     final json = {
@@ -2085,12 +2095,13 @@ class _$TimestampQueryDocumentReference extends FirestoreDocumentReference<
         _$TimestampQueryFieldMap['time']!: timeFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     TimestampQuery model, {
+    SetOptions? options,
     FieldValue? timeFieldValue,
   }) {
     final json = {
@@ -2099,12 +2110,13 @@ class _$TimestampQueryDocumentReference extends FirestoreDocumentReference<
         _$TimestampQueryFieldMap['time']!: timeFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     TimestampQuery model, {
+    SetOptions? options,
     FieldValue? timeFieldValue,
   }) {
     final json = {
@@ -2113,7 +2125,7 @@ class _$TimestampQueryDocumentReference extends FirestoreDocumentReference<
         _$TimestampQueryFieldMap['time']!: timeFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -2912,7 +2924,7 @@ abstract class GeoPointQueryDocumentReference
   /// [model] during serialization.
   Future<void> set(
     GeoPointQuery model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue pointFieldValue,
   });
 
@@ -2926,6 +2938,7 @@ abstract class GeoPointQueryDocumentReference
   void transactionSet(
     Transaction transaction,
     GeoPointQuery model, {
+    SetOptions? options,
     FieldValue pointFieldValue,
   });
 
@@ -2939,6 +2952,7 @@ abstract class GeoPointQueryDocumentReference
   void batchSet(
     WriteBatch batch,
     GeoPointQuery model, {
+    SetOptions? options,
     FieldValue pointFieldValue,
   });
 
@@ -3001,7 +3015,7 @@ class _$GeoPointQueryDocumentReference extends FirestoreDocumentReference<
 
   Future<void> set(
     GeoPointQuery model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? pointFieldValue,
   }) async {
     final json = {
@@ -3010,12 +3024,13 @@ class _$GeoPointQueryDocumentReference extends FirestoreDocumentReference<
         _$GeoPointQueryFieldMap['point']!: pointFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     GeoPointQuery model, {
+    SetOptions? options,
     FieldValue? pointFieldValue,
   }) {
     final json = {
@@ -3024,12 +3039,13 @@ class _$GeoPointQueryDocumentReference extends FirestoreDocumentReference<
         _$GeoPointQueryFieldMap['point']!: pointFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     GeoPointQuery model, {
+    SetOptions? options,
     FieldValue? pointFieldValue,
   }) {
     final json = {
@@ -3038,7 +3054,7 @@ class _$GeoPointQueryDocumentReference extends FirestoreDocumentReference<
         _$GeoPointQueryFieldMap['point']!: pointFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -3839,7 +3855,7 @@ abstract class DocumentReferenceQueryDocumentReference
   /// [model] during serialization.
   Future<void> set(
     DocumentReferenceQuery model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue refFieldValue,
   });
 
@@ -3853,6 +3869,7 @@ abstract class DocumentReferenceQueryDocumentReference
   void transactionSet(
     Transaction transaction,
     DocumentReferenceQuery model, {
+    SetOptions? options,
     FieldValue refFieldValue,
   });
 
@@ -3866,6 +3883,7 @@ abstract class DocumentReferenceQueryDocumentReference
   void batchSet(
     WriteBatch batch,
     DocumentReferenceQuery model, {
+    SetOptions? options,
     FieldValue refFieldValue,
   });
 
@@ -3933,7 +3951,7 @@ class _$DocumentReferenceQueryDocumentReference
 
   Future<void> set(
     DocumentReferenceQuery model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? refFieldValue,
   }) async {
     final json = {
@@ -3942,12 +3960,13 @@ class _$DocumentReferenceQueryDocumentReference
         _$DocumentReferenceQueryFieldMap['ref']!: refFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     DocumentReferenceQuery model, {
+    SetOptions? options,
     FieldValue? refFieldValue,
   }) {
     final json = {
@@ -3956,12 +3975,13 @@ class _$DocumentReferenceQueryDocumentReference
         _$DocumentReferenceQueryFieldMap['ref']!: refFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     DocumentReferenceQuery model, {
+    SetOptions? options,
     FieldValue? refFieldValue,
   }) {
     final json = {
@@ -3970,7 +3990,7 @@ class _$DocumentReferenceQueryDocumentReference
         _$DocumentReferenceQueryFieldMap['ref']!: refFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
@@ -138,7 +138,7 @@ abstract class DurationQueryDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     DurationQuery model, {
     SetOptions? setOptions,
@@ -151,7 +151,7 @@ abstract class DurationQueryDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     DurationQuery model, {
@@ -164,7 +164,7 @@ abstract class DurationQueryDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     DurationQuery model, {
@@ -1060,7 +1060,7 @@ abstract class DateTimeQueryDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     DateTimeQuery model, {
     SetOptions? setOptions,
@@ -1073,7 +1073,7 @@ abstract class DateTimeQueryDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     DateTimeQuery model, {
@@ -1086,7 +1086,7 @@ abstract class DateTimeQueryDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     DateTimeQuery model, {
@@ -1984,7 +1984,7 @@ abstract class TimestampQueryDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     TimestampQuery model, {
     SetOptions? setOptions,
@@ -1997,7 +1997,7 @@ abstract class TimestampQueryDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     TimestampQuery model, {
@@ -2010,7 +2010,7 @@ abstract class TimestampQueryDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     TimestampQuery model, {
@@ -2909,7 +2909,7 @@ abstract class GeoPointQueryDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     GeoPointQuery model, {
     SetOptions? setOptions,
@@ -2922,7 +2922,7 @@ abstract class GeoPointQueryDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     GeoPointQuery model, {
@@ -2935,7 +2935,7 @@ abstract class GeoPointQueryDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     GeoPointQuery model, {
@@ -3836,7 +3836,7 @@ abstract class DocumentReferenceQueryDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     DocumentReferenceQuery model, {
     SetOptions? setOptions,
@@ -3849,7 +3849,7 @@ abstract class DocumentReferenceQueryDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     DocumentReferenceQuery model, {
@@ -3862,7 +3862,7 @@ abstract class DocumentReferenceQueryDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     DocumentReferenceQuery model, {

--- a/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
@@ -131,13 +131,44 @@ abstract class DurationQueryDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    DurationQuery model, {
+    SetOptions? setOptions,
+    FieldValue? durationFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    DurationQuery model, {
+    FieldValue? durationFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    DurationQuery model, {
+    FieldValue? durationFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Duration duration,
-    FieldValue durationFieldValue,
+    Object? duration = _sentinel,
+    FieldValue? durationFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -145,8 +176,8 @@ abstract class DurationQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Duration duration,
-    FieldValue durationFieldValue,
+    Object? duration = _sentinel,
+    FieldValue? durationFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -154,8 +185,8 @@ abstract class DurationQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Duration duration,
-    FieldValue durationFieldValue,
+    Object? duration = _sentinel,
+    FieldValue? durationFieldValue,
   });
 }
 
@@ -186,6 +217,48 @@ class _$DurationQueryDocumentReference extends FirestoreDocumentReference<
   Future<DurationQueryDocumentSnapshot> transactionGet(
       Transaction transaction) {
     return transaction.get(reference).then(DurationQueryDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    DurationQuery model, {
+    SetOptions? setOptions,
+    FieldValue? durationFieldValue,
+  }) async {
+    final json = {
+      ..._$DurationQueryToJson(model),
+      if (durationFieldValue != null)
+        _$DurationQueryFieldMap['duration']!: durationFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    DurationQuery model, {
+    FieldValue? durationFieldValue,
+  }) {
+    final json = {
+      ..._$DurationQueryToJson(model),
+      if (durationFieldValue != null)
+        _$DurationQueryFieldMap['duration']!: durationFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    DurationQuery model, {
+    FieldValue? durationFieldValue,
+  }) {
+    final json = {
+      ..._$DurationQueryToJson(model),
+      if (durationFieldValue != null)
+        _$DurationQueryFieldMap['duration']!: durationFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -971,13 +1044,44 @@ abstract class DateTimeQueryDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    DateTimeQuery model, {
+    SetOptions? setOptions,
+    FieldValue? timeFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    DateTimeQuery model, {
+    FieldValue? timeFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    DateTimeQuery model, {
+    FieldValue? timeFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    DateTime time,
-    FieldValue timeFieldValue,
+    Object? time = _sentinel,
+    FieldValue? timeFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -985,8 +1089,8 @@ abstract class DateTimeQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    DateTime time,
-    FieldValue timeFieldValue,
+    Object? time = _sentinel,
+    FieldValue? timeFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -994,8 +1098,8 @@ abstract class DateTimeQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    DateTime time,
-    FieldValue timeFieldValue,
+    Object? time = _sentinel,
+    FieldValue? timeFieldValue,
   });
 }
 
@@ -1026,6 +1130,48 @@ class _$DateTimeQueryDocumentReference extends FirestoreDocumentReference<
   Future<DateTimeQueryDocumentSnapshot> transactionGet(
       Transaction transaction) {
     return transaction.get(reference).then(DateTimeQueryDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    DateTimeQuery model, {
+    SetOptions? setOptions,
+    FieldValue? timeFieldValue,
+  }) async {
+    final json = {
+      ..._$DateTimeQueryToJson(model),
+      if (timeFieldValue != null)
+        _$DateTimeQueryFieldMap['time']!: timeFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    DateTimeQuery model, {
+    FieldValue? timeFieldValue,
+  }) {
+    final json = {
+      ..._$DateTimeQueryToJson(model),
+      if (timeFieldValue != null)
+        _$DateTimeQueryFieldMap['time']!: timeFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    DateTimeQuery model, {
+    FieldValue? timeFieldValue,
+  }) {
+    final json = {
+      ..._$DateTimeQueryToJson(model),
+      if (timeFieldValue != null)
+        _$DateTimeQueryFieldMap['time']!: timeFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -1813,13 +1959,44 @@ abstract class TimestampQueryDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    TimestampQuery model, {
+    SetOptions? setOptions,
+    FieldValue? timeFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    TimestampQuery model, {
+    FieldValue? timeFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    TimestampQuery model, {
+    FieldValue? timeFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Timestamp time,
-    FieldValue timeFieldValue,
+    Object? time = _sentinel,
+    FieldValue? timeFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -1827,8 +2004,8 @@ abstract class TimestampQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Timestamp time,
-    FieldValue timeFieldValue,
+    Object? time = _sentinel,
+    FieldValue? timeFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -1836,8 +2013,8 @@ abstract class TimestampQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Timestamp time,
-    FieldValue timeFieldValue,
+    Object? time = _sentinel,
+    FieldValue? timeFieldValue,
   });
 }
 
@@ -1868,6 +2045,48 @@ class _$TimestampQueryDocumentReference extends FirestoreDocumentReference<
   Future<TimestampQueryDocumentSnapshot> transactionGet(
       Transaction transaction) {
     return transaction.get(reference).then(TimestampQueryDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    TimestampQuery model, {
+    SetOptions? setOptions,
+    FieldValue? timeFieldValue,
+  }) async {
+    final json = {
+      ..._$TimestampQueryToJson(model),
+      if (timeFieldValue != null)
+        _$TimestampQueryFieldMap['time']!: timeFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    TimestampQuery model, {
+    FieldValue? timeFieldValue,
+  }) {
+    final json = {
+      ..._$TimestampQueryToJson(model),
+      if (timeFieldValue != null)
+        _$TimestampQueryFieldMap['time']!: timeFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    TimestampQuery model, {
+    FieldValue? timeFieldValue,
+  }) {
+    final json = {
+      ..._$TimestampQueryToJson(model),
+      if (timeFieldValue != null)
+        _$TimestampQueryFieldMap['time']!: timeFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -2656,13 +2875,44 @@ abstract class GeoPointQueryDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    GeoPointQuery model, {
+    SetOptions? setOptions,
+    FieldValue? pointFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    GeoPointQuery model, {
+    FieldValue? pointFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    GeoPointQuery model, {
+    FieldValue? pointFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    GeoPoint point,
-    FieldValue pointFieldValue,
+    Object? point = _sentinel,
+    FieldValue? pointFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -2670,8 +2920,8 @@ abstract class GeoPointQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    GeoPoint point,
-    FieldValue pointFieldValue,
+    Object? point = _sentinel,
+    FieldValue? pointFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -2679,8 +2929,8 @@ abstract class GeoPointQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    GeoPoint point,
-    FieldValue pointFieldValue,
+    Object? point = _sentinel,
+    FieldValue? pointFieldValue,
   });
 }
 
@@ -2711,6 +2961,48 @@ class _$GeoPointQueryDocumentReference extends FirestoreDocumentReference<
   Future<GeoPointQueryDocumentSnapshot> transactionGet(
       Transaction transaction) {
     return transaction.get(reference).then(GeoPointQueryDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    GeoPointQuery model, {
+    SetOptions? setOptions,
+    FieldValue? pointFieldValue,
+  }) async {
+    final json = {
+      ..._$GeoPointQueryToJson(model),
+      if (pointFieldValue != null)
+        _$GeoPointQueryFieldMap['point']!: pointFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    GeoPointQuery model, {
+    FieldValue? pointFieldValue,
+  }) {
+    final json = {
+      ..._$GeoPointQueryToJson(model),
+      if (pointFieldValue != null)
+        _$GeoPointQueryFieldMap['point']!: pointFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    GeoPointQuery model, {
+    FieldValue? pointFieldValue,
+  }) {
+    final json = {
+      ..._$GeoPointQueryToJson(model),
+      if (pointFieldValue != null)
+        _$GeoPointQueryFieldMap['point']!: pointFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -3501,13 +3793,44 @@ abstract class DocumentReferenceQueryDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    DocumentReferenceQuery model, {
+    SetOptions? setOptions,
+    FieldValue? refFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    DocumentReferenceQuery model, {
+    FieldValue? refFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    DocumentReferenceQuery model, {
+    FieldValue? refFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    DocumentReference<Map<String, dynamic>> ref,
-    FieldValue refFieldValue,
+    Object? ref = _sentinel,
+    FieldValue? refFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -3515,8 +3838,8 @@ abstract class DocumentReferenceQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    DocumentReference<Map<String, dynamic>> ref,
-    FieldValue refFieldValue,
+    Object? ref = _sentinel,
+    FieldValue? refFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -3524,8 +3847,8 @@ abstract class DocumentReferenceQueryDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    DocumentReference<Map<String, dynamic>> ref,
-    FieldValue refFieldValue,
+    Object? ref = _sentinel,
+    FieldValue? refFieldValue,
   });
 }
 
@@ -3561,6 +3884,48 @@ class _$DocumentReferenceQueryDocumentReference
     return transaction
         .get(reference)
         .then(DocumentReferenceQueryDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    DocumentReferenceQuery model, {
+    SetOptions? setOptions,
+    FieldValue? refFieldValue,
+  }) async {
+    final json = {
+      ..._$DocumentReferenceQueryToJson(model),
+      if (refFieldValue != null)
+        _$DocumentReferenceQueryFieldMap['ref']!: refFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    DocumentReferenceQuery model, {
+    FieldValue? refFieldValue,
+  }) {
+    final json = {
+      ..._$DocumentReferenceQueryToJson(model),
+      if (refFieldValue != null)
+        _$DocumentReferenceQueryFieldMap['ref']!: refFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    DocumentReferenceQuery model, {
+    FieldValue? refFieldValue,
+  }) {
+    final json = {
+      ..._$DocumentReferenceQueryToJson(model),
+      if (refFieldValue != null)
+        _$DocumentReferenceQueryFieldMap['ref']!: refFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -4257,7 +4622,7 @@ class DocumentReferenceQueryQueryDocumentSnapshot
 
 DurationQuery _$DurationQueryFromJson(Map<String, dynamic> json) =>
     DurationQuery(
-      Duration(microseconds: json['duration'] as int),
+      Duration(microseconds: (json['duration'] as num).toInt()),
     );
 
 const _$DurationQueryFieldMap = <String, String>{

--- a/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
@@ -136,6 +136,9 @@ abstract class DurationQueryDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     DurationQuery model, {
     SetOptions? setOptions,
@@ -146,6 +149,9 @@ abstract class DurationQueryDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     DurationQuery model, {
@@ -156,6 +162,9 @@ abstract class DurationQueryDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     DurationQuery model, {
@@ -1049,6 +1058,9 @@ abstract class DateTimeQueryDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     DateTimeQuery model, {
     SetOptions? setOptions,
@@ -1059,6 +1071,9 @@ abstract class DateTimeQueryDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     DateTimeQuery model, {
@@ -1069,6 +1084,9 @@ abstract class DateTimeQueryDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     DateTimeQuery model, {
@@ -1964,6 +1982,9 @@ abstract class TimestampQueryDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     TimestampQuery model, {
     SetOptions? setOptions,
@@ -1974,6 +1995,9 @@ abstract class TimestampQueryDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     TimestampQuery model, {
@@ -1984,6 +2008,9 @@ abstract class TimestampQueryDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     TimestampQuery model, {
@@ -2880,6 +2907,9 @@ abstract class GeoPointQueryDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     GeoPointQuery model, {
     SetOptions? setOptions,
@@ -2890,6 +2920,9 @@ abstract class GeoPointQueryDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     GeoPointQuery model, {
@@ -2900,6 +2933,9 @@ abstract class GeoPointQueryDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     GeoPointQuery model, {
@@ -3798,6 +3834,9 @@ abstract class DocumentReferenceQueryDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     DocumentReferenceQuery model, {
     SetOptions? setOptions,
@@ -3808,6 +3847,9 @@ abstract class DocumentReferenceQueryDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     DocumentReferenceQuery model, {
@@ -3818,6 +3860,9 @@ abstract class DocumentReferenceQueryDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     DocumentReferenceQuery model, {

--- a/packages/cloud_firestore_odm/example/lib/movie.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/movie.g.dart
@@ -135,6 +135,9 @@ abstract class MovieDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     Movie model, {
     SetOptions? setOptions,
@@ -152,6 +155,9 @@ abstract class MovieDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     Movie model, {
@@ -169,6 +175,9 @@ abstract class MovieDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     Movie model, {
@@ -2354,6 +2363,9 @@ abstract class CommentDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     Comment model, {
     SetOptions? setOptions,
@@ -2365,6 +2377,9 @@ abstract class CommentDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     Comment model, {
@@ -2376,6 +2391,9 @@ abstract class CommentDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     Comment model, {

--- a/packages/cloud_firestore_odm/example/lib/movie.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/movie.g.dart
@@ -137,7 +137,7 @@ abstract class MovieDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     Movie model, {
     SetOptions? setOptions,
@@ -157,7 +157,7 @@ abstract class MovieDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     Movie model, {
@@ -177,7 +177,7 @@ abstract class MovieDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     Movie model, {
@@ -2365,7 +2365,7 @@ abstract class CommentDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     Comment model, {
     SetOptions? setOptions,
@@ -2379,7 +2379,7 @@ abstract class CommentDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     Comment model, {
@@ -2393,7 +2393,7 @@ abstract class CommentDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     Comment model, {

--- a/packages/cloud_firestore_odm/example/lib/movie.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/movie.g.dart
@@ -130,27 +130,79 @@ abstract class MovieDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    Movie model, {
+    SetOptions? setOptions,
+    FieldValue? posterFieldValue,
+    FieldValue? likesFieldValue,
+    FieldValue? titleFieldValue,
+    FieldValue? yearFieldValue,
+    FieldValue? runtimeFieldValue,
+    FieldValue? ratedFieldValue,
+    FieldValue? genreFieldValue,
+    FieldValue? tagsFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    Movie model, {
+    FieldValue? posterFieldValue,
+    FieldValue? likesFieldValue,
+    FieldValue? titleFieldValue,
+    FieldValue? yearFieldValue,
+    FieldValue? runtimeFieldValue,
+    FieldValue? ratedFieldValue,
+    FieldValue? genreFieldValue,
+    FieldValue? tagsFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    Movie model, {
+    FieldValue? posterFieldValue,
+    FieldValue? likesFieldValue,
+    FieldValue? titleFieldValue,
+    FieldValue? yearFieldValue,
+    FieldValue? runtimeFieldValue,
+    FieldValue? ratedFieldValue,
+    FieldValue? genreFieldValue,
+    FieldValue? tagsFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    String poster,
-    FieldValue posterFieldValue,
-    int likes,
-    FieldValue likesFieldValue,
-    String title,
-    FieldValue titleFieldValue,
-    int year,
-    FieldValue yearFieldValue,
-    String runtime,
-    FieldValue runtimeFieldValue,
-    String rated,
-    FieldValue ratedFieldValue,
-    List<String>? genre,
-    FieldValue genreFieldValue,
-    Set<String>? tags,
-    FieldValue tagsFieldValue,
+    Object? poster = _sentinel,
+    FieldValue? posterFieldValue,
+    Object? likes = _sentinel,
+    FieldValue? likesFieldValue,
+    Object? title = _sentinel,
+    FieldValue? titleFieldValue,
+    Object? year = _sentinel,
+    FieldValue? yearFieldValue,
+    Object? runtime = _sentinel,
+    FieldValue? runtimeFieldValue,
+    Object? rated = _sentinel,
+    FieldValue? ratedFieldValue,
+    Object? genre = _sentinel,
+    FieldValue? genreFieldValue,
+    Object? tags = _sentinel,
+    FieldValue? tagsFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -158,22 +210,22 @@ abstract class MovieDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    String poster,
-    FieldValue posterFieldValue,
-    int likes,
-    FieldValue likesFieldValue,
-    String title,
-    FieldValue titleFieldValue,
-    int year,
-    FieldValue yearFieldValue,
-    String runtime,
-    FieldValue runtimeFieldValue,
-    String rated,
-    FieldValue ratedFieldValue,
-    List<String>? genre,
-    FieldValue genreFieldValue,
-    Set<String>? tags,
-    FieldValue tagsFieldValue,
+    Object? poster = _sentinel,
+    FieldValue? posterFieldValue,
+    Object? likes = _sentinel,
+    FieldValue? likesFieldValue,
+    Object? title = _sentinel,
+    FieldValue? titleFieldValue,
+    Object? year = _sentinel,
+    FieldValue? yearFieldValue,
+    Object? runtime = _sentinel,
+    FieldValue? runtimeFieldValue,
+    Object? rated = _sentinel,
+    FieldValue? ratedFieldValue,
+    Object? genre = _sentinel,
+    FieldValue? genreFieldValue,
+    Object? tags = _sentinel,
+    FieldValue? tagsFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -181,22 +233,22 @@ abstract class MovieDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    String poster,
-    FieldValue posterFieldValue,
-    int likes,
-    FieldValue likesFieldValue,
-    String title,
-    FieldValue titleFieldValue,
-    int year,
-    FieldValue yearFieldValue,
-    String runtime,
-    FieldValue runtimeFieldValue,
-    String rated,
-    FieldValue ratedFieldValue,
-    List<String>? genre,
-    FieldValue genreFieldValue,
-    Set<String>? tags,
-    FieldValue tagsFieldValue,
+    Object? poster = _sentinel,
+    FieldValue? posterFieldValue,
+    Object? likes = _sentinel,
+    FieldValue? likesFieldValue,
+    Object? title = _sentinel,
+    FieldValue? titleFieldValue,
+    Object? year = _sentinel,
+    FieldValue? yearFieldValue,
+    Object? runtime = _sentinel,
+    FieldValue? runtimeFieldValue,
+    Object? rated = _sentinel,
+    FieldValue? ratedFieldValue,
+    Object? genre = _sentinel,
+    FieldValue? genreFieldValue,
+    Object? tags = _sentinel,
+    FieldValue? tagsFieldValue,
   });
 }
 
@@ -230,6 +282,93 @@ class _$MovieDocumentReference
   @override
   Future<MovieDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(MovieDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    Movie model, {
+    SetOptions? setOptions,
+    FieldValue? posterFieldValue,
+    FieldValue? likesFieldValue,
+    FieldValue? titleFieldValue,
+    FieldValue? yearFieldValue,
+    FieldValue? runtimeFieldValue,
+    FieldValue? ratedFieldValue,
+    FieldValue? genreFieldValue,
+    FieldValue? tagsFieldValue,
+  }) async {
+    final json = {
+      ..._$MovieToJson(model),
+      if (posterFieldValue != null)
+        _$MovieFieldMap['poster']!: posterFieldValue,
+      if (likesFieldValue != null) _$MovieFieldMap['likes']!: likesFieldValue,
+      if (titleFieldValue != null) _$MovieFieldMap['title']!: titleFieldValue,
+      if (yearFieldValue != null) _$MovieFieldMap['year']!: yearFieldValue,
+      if (runtimeFieldValue != null)
+        _$MovieFieldMap['runtime']!: runtimeFieldValue,
+      if (ratedFieldValue != null) _$MovieFieldMap['rated']!: ratedFieldValue,
+      if (genreFieldValue != null) _$MovieFieldMap['genre']!: genreFieldValue,
+      if (tagsFieldValue != null) _$MovieFieldMap['tags']!: tagsFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    Movie model, {
+    FieldValue? posterFieldValue,
+    FieldValue? likesFieldValue,
+    FieldValue? titleFieldValue,
+    FieldValue? yearFieldValue,
+    FieldValue? runtimeFieldValue,
+    FieldValue? ratedFieldValue,
+    FieldValue? genreFieldValue,
+    FieldValue? tagsFieldValue,
+  }) {
+    final json = {
+      ..._$MovieToJson(model),
+      if (posterFieldValue != null)
+        _$MovieFieldMap['poster']!: posterFieldValue,
+      if (likesFieldValue != null) _$MovieFieldMap['likes']!: likesFieldValue,
+      if (titleFieldValue != null) _$MovieFieldMap['title']!: titleFieldValue,
+      if (yearFieldValue != null) _$MovieFieldMap['year']!: yearFieldValue,
+      if (runtimeFieldValue != null)
+        _$MovieFieldMap['runtime']!: runtimeFieldValue,
+      if (ratedFieldValue != null) _$MovieFieldMap['rated']!: ratedFieldValue,
+      if (genreFieldValue != null) _$MovieFieldMap['genre']!: genreFieldValue,
+      if (tagsFieldValue != null) _$MovieFieldMap['tags']!: tagsFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    Movie model, {
+    FieldValue? posterFieldValue,
+    FieldValue? likesFieldValue,
+    FieldValue? titleFieldValue,
+    FieldValue? yearFieldValue,
+    FieldValue? runtimeFieldValue,
+    FieldValue? ratedFieldValue,
+    FieldValue? genreFieldValue,
+    FieldValue? tagsFieldValue,
+  }) {
+    final json = {
+      ..._$MovieToJson(model),
+      if (posterFieldValue != null)
+        _$MovieFieldMap['poster']!: posterFieldValue,
+      if (likesFieldValue != null) _$MovieFieldMap['likes']!: likesFieldValue,
+      if (titleFieldValue != null) _$MovieFieldMap['title']!: titleFieldValue,
+      if (yearFieldValue != null) _$MovieFieldMap['year']!: yearFieldValue,
+      if (runtimeFieldValue != null)
+        _$MovieFieldMap['runtime']!: runtimeFieldValue,
+      if (ratedFieldValue != null) _$MovieFieldMap['rated']!: ratedFieldValue,
+      if (genreFieldValue != null) _$MovieFieldMap['genre']!: genreFieldValue,
+      if (tagsFieldValue != null) _$MovieFieldMap['tags']!: tagsFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -2210,15 +2349,49 @@ abstract class CommentDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    Comment model, {
+    SetOptions? setOptions,
+    FieldValue? authorNameFieldValue,
+    FieldValue? messageFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    Comment model, {
+    FieldValue? authorNameFieldValue,
+    FieldValue? messageFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    Comment model, {
+    FieldValue? authorNameFieldValue,
+    FieldValue? messageFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    String authorName,
-    FieldValue authorNameFieldValue,
-    String message,
-    FieldValue messageFieldValue,
+    Object? authorName = _sentinel,
+    FieldValue? authorNameFieldValue,
+    Object? message = _sentinel,
+    FieldValue? messageFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -2226,10 +2399,10 @@ abstract class CommentDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    String authorName,
-    FieldValue authorNameFieldValue,
-    String message,
-    FieldValue messageFieldValue,
+    Object? authorName = _sentinel,
+    FieldValue? authorNameFieldValue,
+    Object? message = _sentinel,
+    FieldValue? messageFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -2237,10 +2410,10 @@ abstract class CommentDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    String authorName,
-    FieldValue authorNameFieldValue,
-    String message,
-    FieldValue messageFieldValue,
+    Object? authorName = _sentinel,
+    FieldValue? authorNameFieldValue,
+    Object? message = _sentinel,
+    FieldValue? messageFieldValue,
   });
 }
 
@@ -2275,6 +2448,57 @@ class _$CommentDocumentReference
   @override
   Future<CommentDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(CommentDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    Comment model, {
+    SetOptions? setOptions,
+    FieldValue? authorNameFieldValue,
+    FieldValue? messageFieldValue,
+  }) async {
+    final json = {
+      ..._$CommentToJson(model),
+      if (authorNameFieldValue != null)
+        _$CommentFieldMap['authorName']!: authorNameFieldValue,
+      if (messageFieldValue != null)
+        _$CommentFieldMap['message']!: messageFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    Comment model, {
+    FieldValue? authorNameFieldValue,
+    FieldValue? messageFieldValue,
+  }) {
+    final json = {
+      ..._$CommentToJson(model),
+      if (authorNameFieldValue != null)
+        _$CommentFieldMap['authorName']!: authorNameFieldValue,
+      if (messageFieldValue != null)
+        _$CommentFieldMap['message']!: messageFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    Comment model, {
+    FieldValue? authorNameFieldValue,
+    FieldValue? messageFieldValue,
+  }) {
+    final json = {
+      ..._$CommentToJson(model),
+      if (authorNameFieldValue != null)
+        _$CommentFieldMap['authorName']!: authorNameFieldValue,
+      if (messageFieldValue != null)
+        _$CommentFieldMap['message']!: messageFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -3131,12 +3355,12 @@ Movie _$MovieFromJson(Map<String, dynamic> json) => Movie(
       genre:
           (json['genre'] as List<dynamic>?)?.map((e) => e as String).toList(),
       tags: (json['tags'] as List<dynamic>?)?.map((e) => e as String).toSet(),
-      likes: json['likes'] as int,
+      likes: (json['likes'] as num).toInt(),
       poster: json['poster'] as String,
       rated: json['rated'] as String,
       runtime: json['runtime'] as String,
       title: json['title'] as String,
-      year: json['year'] as int,
+      year: (json['year'] as num).toInt(),
       id: json['id'] as String,
     );
 

--- a/packages/cloud_firestore_odm/example/lib/movie.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/movie.g.dart
@@ -321,7 +321,11 @@ class _$MovieDocumentReference
       if (tagsFieldValue != null) _$MovieFieldMap['tags']!: tagsFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -2488,7 +2492,11 @@ class _$CommentDocumentReference
         _$CommentFieldMap['message']!: messageFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(

--- a/packages/cloud_firestore_odm/example/lib/movie.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/movie.g.dart
@@ -138,14 +138,14 @@ abstract class MovieDocumentReference
   Future<void> set(
     Movie model, {
     SetOptions? setOptions,
-    FieldValue? posterFieldValue,
-    FieldValue? likesFieldValue,
-    FieldValue? titleFieldValue,
-    FieldValue? yearFieldValue,
-    FieldValue? runtimeFieldValue,
-    FieldValue? ratedFieldValue,
-    FieldValue? genreFieldValue,
-    FieldValue? tagsFieldValue,
+    FieldValue posterFieldValue,
+    FieldValue likesFieldValue,
+    FieldValue titleFieldValue,
+    FieldValue yearFieldValue,
+    FieldValue runtimeFieldValue,
+    FieldValue ratedFieldValue,
+    FieldValue genreFieldValue,
+    FieldValue tagsFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -155,14 +155,14 @@ abstract class MovieDocumentReference
   void transactionSet(
     Transaction transaction,
     Movie model, {
-    FieldValue? posterFieldValue,
-    FieldValue? likesFieldValue,
-    FieldValue? titleFieldValue,
-    FieldValue? yearFieldValue,
-    FieldValue? runtimeFieldValue,
-    FieldValue? ratedFieldValue,
-    FieldValue? genreFieldValue,
-    FieldValue? tagsFieldValue,
+    FieldValue posterFieldValue,
+    FieldValue likesFieldValue,
+    FieldValue titleFieldValue,
+    FieldValue yearFieldValue,
+    FieldValue runtimeFieldValue,
+    FieldValue ratedFieldValue,
+    FieldValue genreFieldValue,
+    FieldValue tagsFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -172,14 +172,14 @@ abstract class MovieDocumentReference
   void batchSet(
     WriteBatch batch,
     Movie model, {
-    FieldValue? posterFieldValue,
-    FieldValue? likesFieldValue,
-    FieldValue? titleFieldValue,
-    FieldValue? yearFieldValue,
-    FieldValue? runtimeFieldValue,
-    FieldValue? ratedFieldValue,
-    FieldValue? genreFieldValue,
-    FieldValue? tagsFieldValue,
+    FieldValue posterFieldValue,
+    FieldValue likesFieldValue,
+    FieldValue titleFieldValue,
+    FieldValue yearFieldValue,
+    FieldValue runtimeFieldValue,
+    FieldValue ratedFieldValue,
+    FieldValue genreFieldValue,
+    FieldValue tagsFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -188,21 +188,21 @@ abstract class MovieDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     String poster,
-    FieldValue? posterFieldValue,
+    FieldValue posterFieldValue,
     int likes,
-    FieldValue? likesFieldValue,
+    FieldValue likesFieldValue,
     String title,
-    FieldValue? titleFieldValue,
+    FieldValue titleFieldValue,
     int year,
-    FieldValue? yearFieldValue,
+    FieldValue yearFieldValue,
     String runtime,
-    FieldValue? runtimeFieldValue,
+    FieldValue runtimeFieldValue,
     String rated,
-    FieldValue? ratedFieldValue,
+    FieldValue ratedFieldValue,
     List<String>? genre,
-    FieldValue? genreFieldValue,
+    FieldValue genreFieldValue,
     Set<String>? tags,
-    FieldValue? tagsFieldValue,
+    FieldValue tagsFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -211,21 +211,21 @@ abstract class MovieDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     String poster,
-    FieldValue? posterFieldValue,
+    FieldValue posterFieldValue,
     int likes,
-    FieldValue? likesFieldValue,
+    FieldValue likesFieldValue,
     String title,
-    FieldValue? titleFieldValue,
+    FieldValue titleFieldValue,
     int year,
-    FieldValue? yearFieldValue,
+    FieldValue yearFieldValue,
     String runtime,
-    FieldValue? runtimeFieldValue,
+    FieldValue runtimeFieldValue,
     String rated,
-    FieldValue? ratedFieldValue,
+    FieldValue ratedFieldValue,
     List<String>? genre,
-    FieldValue? genreFieldValue,
+    FieldValue genreFieldValue,
     Set<String>? tags,
-    FieldValue? tagsFieldValue,
+    FieldValue tagsFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -234,21 +234,21 @@ abstract class MovieDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     String poster,
-    FieldValue? posterFieldValue,
+    FieldValue posterFieldValue,
     int likes,
-    FieldValue? likesFieldValue,
+    FieldValue likesFieldValue,
     String title,
-    FieldValue? titleFieldValue,
+    FieldValue titleFieldValue,
     int year,
-    FieldValue? yearFieldValue,
+    FieldValue yearFieldValue,
     String runtime,
-    FieldValue? runtimeFieldValue,
+    FieldValue runtimeFieldValue,
     String rated,
-    FieldValue? ratedFieldValue,
+    FieldValue ratedFieldValue,
     List<String>? genre,
-    FieldValue? genreFieldValue,
+    FieldValue genreFieldValue,
     Set<String>? tags,
-    FieldValue? tagsFieldValue,
+    FieldValue tagsFieldValue,
   });
 }
 
@@ -2357,8 +2357,8 @@ abstract class CommentDocumentReference
   Future<void> set(
     Comment model, {
     SetOptions? setOptions,
-    FieldValue? authorNameFieldValue,
-    FieldValue? messageFieldValue,
+    FieldValue authorNameFieldValue,
+    FieldValue messageFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -2368,8 +2368,8 @@ abstract class CommentDocumentReference
   void transactionSet(
     Transaction transaction,
     Comment model, {
-    FieldValue? authorNameFieldValue,
-    FieldValue? messageFieldValue,
+    FieldValue authorNameFieldValue,
+    FieldValue messageFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -2379,8 +2379,8 @@ abstract class CommentDocumentReference
   void batchSet(
     WriteBatch batch,
     Comment model, {
-    FieldValue? authorNameFieldValue,
-    FieldValue? messageFieldValue,
+    FieldValue authorNameFieldValue,
+    FieldValue messageFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -2389,9 +2389,9 @@ abstract class CommentDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     String authorName,
-    FieldValue? authorNameFieldValue,
+    FieldValue authorNameFieldValue,
     String message,
-    FieldValue? messageFieldValue,
+    FieldValue messageFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -2400,9 +2400,9 @@ abstract class CommentDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     String authorName,
-    FieldValue? authorNameFieldValue,
+    FieldValue authorNameFieldValue,
     String message,
-    FieldValue? messageFieldValue,
+    FieldValue messageFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -2411,9 +2411,9 @@ abstract class CommentDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     String authorName,
-    FieldValue? authorNameFieldValue,
+    FieldValue authorNameFieldValue,
     String message,
-    FieldValue? messageFieldValue,
+    FieldValue messageFieldValue,
   });
 }
 

--- a/packages/cloud_firestore_odm/example/lib/movie.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/movie.g.dart
@@ -187,21 +187,21 @@ abstract class MovieDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? poster = _sentinel,
+    String poster,
     FieldValue? posterFieldValue,
-    Object? likes = _sentinel,
+    int likes,
     FieldValue? likesFieldValue,
-    Object? title = _sentinel,
+    String title,
     FieldValue? titleFieldValue,
-    Object? year = _sentinel,
+    int year,
     FieldValue? yearFieldValue,
-    Object? runtime = _sentinel,
+    String runtime,
     FieldValue? runtimeFieldValue,
-    Object? rated = _sentinel,
+    String rated,
     FieldValue? ratedFieldValue,
-    Object? genre = _sentinel,
+    List<String>? genre,
     FieldValue? genreFieldValue,
-    Object? tags = _sentinel,
+    Set<String>? tags,
     FieldValue? tagsFieldValue,
   });
 
@@ -210,21 +210,21 @@ abstract class MovieDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? poster = _sentinel,
+    String poster,
     FieldValue? posterFieldValue,
-    Object? likes = _sentinel,
+    int likes,
     FieldValue? likesFieldValue,
-    Object? title = _sentinel,
+    String title,
     FieldValue? titleFieldValue,
-    Object? year = _sentinel,
+    int year,
     FieldValue? yearFieldValue,
-    Object? runtime = _sentinel,
+    String runtime,
     FieldValue? runtimeFieldValue,
-    Object? rated = _sentinel,
+    String rated,
     FieldValue? ratedFieldValue,
-    Object? genre = _sentinel,
+    List<String>? genre,
     FieldValue? genreFieldValue,
-    Object? tags = _sentinel,
+    Set<String>? tags,
     FieldValue? tagsFieldValue,
   });
 
@@ -233,21 +233,21 @@ abstract class MovieDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? poster = _sentinel,
+    String poster,
     FieldValue? posterFieldValue,
-    Object? likes = _sentinel,
+    int likes,
     FieldValue? likesFieldValue,
-    Object? title = _sentinel,
+    String title,
     FieldValue? titleFieldValue,
-    Object? year = _sentinel,
+    int year,
     FieldValue? yearFieldValue,
-    Object? runtime = _sentinel,
+    String runtime,
     FieldValue? runtimeFieldValue,
-    Object? rated = _sentinel,
+    String rated,
     FieldValue? ratedFieldValue,
-    Object? genre = _sentinel,
+    List<String>? genre,
     FieldValue? genreFieldValue,
-    Object? tags = _sentinel,
+    Set<String>? tags,
     FieldValue? tagsFieldValue,
   });
 }
@@ -2388,9 +2388,9 @@ abstract class CommentDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? authorName = _sentinel,
+    String authorName,
     FieldValue? authorNameFieldValue,
-    Object? message = _sentinel,
+    String message,
     FieldValue? messageFieldValue,
   });
 
@@ -2399,9 +2399,9 @@ abstract class CommentDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? authorName = _sentinel,
+    String authorName,
     FieldValue? authorNameFieldValue,
-    Object? message = _sentinel,
+    String message,
     FieldValue? messageFieldValue,
   });
 
@@ -2410,9 +2410,9 @@ abstract class CommentDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? authorName = _sentinel,
+    String authorName,
     FieldValue? authorNameFieldValue,
-    Object? message = _sentinel,
+    String message,
     FieldValue? messageFieldValue,
   });
 }

--- a/packages/cloud_firestore_odm/example/lib/movie.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/movie.g.dart
@@ -140,7 +140,7 @@ abstract class MovieDocumentReference
   /// [model] during serialization.
   Future<void> set(
     Movie model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue posterFieldValue,
     FieldValue likesFieldValue,
     FieldValue titleFieldValue,
@@ -161,6 +161,7 @@ abstract class MovieDocumentReference
   void transactionSet(
     Transaction transaction,
     Movie model, {
+    SetOptions? options,
     FieldValue posterFieldValue,
     FieldValue likesFieldValue,
     FieldValue titleFieldValue,
@@ -181,6 +182,7 @@ abstract class MovieDocumentReference
   void batchSet(
     WriteBatch batch,
     Movie model, {
+    SetOptions? options,
     FieldValue posterFieldValue,
     FieldValue likesFieldValue,
     FieldValue titleFieldValue,
@@ -295,7 +297,7 @@ class _$MovieDocumentReference
 
   Future<void> set(
     Movie model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? posterFieldValue,
     FieldValue? likesFieldValue,
     FieldValue? titleFieldValue,
@@ -319,12 +321,13 @@ class _$MovieDocumentReference
       if (tagsFieldValue != null) _$MovieFieldMap['tags']!: tagsFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     Movie model, {
+    SetOptions? options,
     FieldValue? posterFieldValue,
     FieldValue? likesFieldValue,
     FieldValue? titleFieldValue,
@@ -348,12 +351,13 @@ class _$MovieDocumentReference
       if (tagsFieldValue != null) _$MovieFieldMap['tags']!: tagsFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     Movie model, {
+    SetOptions? options,
     FieldValue? posterFieldValue,
     FieldValue? likesFieldValue,
     FieldValue? titleFieldValue,
@@ -377,7 +381,7 @@ class _$MovieDocumentReference
       if (tagsFieldValue != null) _$MovieFieldMap['tags']!: tagsFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -2368,7 +2372,7 @@ abstract class CommentDocumentReference
   /// [model] during serialization.
   Future<void> set(
     Comment model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue authorNameFieldValue,
     FieldValue messageFieldValue,
   });
@@ -2383,6 +2387,7 @@ abstract class CommentDocumentReference
   void transactionSet(
     Transaction transaction,
     Comment model, {
+    SetOptions? options,
     FieldValue authorNameFieldValue,
     FieldValue messageFieldValue,
   });
@@ -2397,6 +2402,7 @@ abstract class CommentDocumentReference
   void batchSet(
     WriteBatch batch,
     Comment model, {
+    SetOptions? options,
     FieldValue authorNameFieldValue,
     FieldValue messageFieldValue,
   });
@@ -2470,7 +2476,7 @@ class _$CommentDocumentReference
 
   Future<void> set(
     Comment model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? authorNameFieldValue,
     FieldValue? messageFieldValue,
   }) async {
@@ -2482,12 +2488,13 @@ class _$CommentDocumentReference
         _$CommentFieldMap['message']!: messageFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     Comment model, {
+    SetOptions? options,
     FieldValue? authorNameFieldValue,
     FieldValue? messageFieldValue,
   }) {
@@ -2499,12 +2506,13 @@ class _$CommentDocumentReference
         _$CommentFieldMap['message']!: messageFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     Comment model, {
+    SetOptions? options,
     FieldValue? authorNameFieldValue,
     FieldValue? messageFieldValue,
   }) {
@@ -2516,7 +2524,7 @@ class _$CommentDocumentReference
         _$CommentFieldMap['message']!: messageFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/pubspec.yaml
+++ b/packages/cloud_firestore_odm/example/pubspec.yaml
@@ -29,5 +29,9 @@ dev_dependencies:
   json_serializable: ^6.6.1
   mockito: ^5.0.0
 
+dependency_overrides:
+  cloud_firestore_odm:
+    path: ../
+
 flutter:
   uses-material-design: true

--- a/packages/cloud_firestore_odm/lib/cloud_firestore_odm.dart
+++ b/packages/cloud_firestore_odm/lib/cloud_firestore_odm.dart
@@ -36,6 +36,7 @@ const List<JsonConverter<Object?, Object?>> firestoreJsonConverters = [
 ];
 
 /// A [JsonConverter] that adds support for [Timestamp] objects within ODM models.
+@JsonSerializable()
 class FirestoreTimestampConverter extends JsonConverter<Timestamp, Timestamp> {
   const FirestoreTimestampConverter();
   @override

--- a/packages/cloud_firestore_odm/lib/cloud_firestore_odm.dart
+++ b/packages/cloud_firestore_odm/lib/cloud_firestore_odm.dart
@@ -36,7 +36,6 @@ const List<JsonConverter<Object?, Object?>> firestoreJsonConverters = [
 ];
 
 /// A [JsonConverter] that adds support for [Timestamp] objects within ODM models.
-@JsonSerializable()
 class FirestoreTimestampConverter extends JsonConverter<Timestamp, Timestamp> {
   const FirestoreTimestampConverter();
   @override

--- a/packages/cloud_firestore_odm/lib/src/firestore_reference.dart
+++ b/packages/cloud_firestore_odm/lib/src/firestore_reference.dart
@@ -81,39 +81,6 @@ abstract class FirestoreDocumentReference<Model,
     batch.delete(reference);
   }
 
-  /// Sets data on the document, overwriting any existing data. If the document
-  /// does not yet exist, it will be created.
-  ///
-  /// If [SetOptions] are provided, the data can be merged into an existing
-  /// document instead of overwriting.
-  Future<void> set(Model model, [SetOptions? setOptions]) {
-    return reference.set(model, setOptions);
-  }
-
-  /// Writes to the document using the transaction API.
-  ///
-  /// If the document does not exist yet, it will be created. If you pass
-  /// [SetOptions], the provided data can be merged into the existing document.
-  void transactionSet(
-    Transaction transaction,
-    Model model, [
-    SetOptions? setOptions,
-  ]) {
-    transaction.set(reference, model, setOptions);
-  }
-
-  /// Writes to the document using the batch API.
-  ///
-  /// If the document does not exist yet, it will be created. If you pass
-  /// [SetOptions], the provided data can be merged into the existing document.
-  void batchSet(
-    WriteBatch batch,
-    Model model, [
-    SetOptions? setOptions,
-  ]) {
-    batch.set(reference, model, setOptions);
-  }
-
   /// Reads the document referred to by this DocumentReference.
   ///
   /// Note:

--- a/packages/cloud_firestore_odm/pubspec.yaml
+++ b/packages/cloud_firestore_odm/pubspec.yaml
@@ -2,7 +2,7 @@ name: cloud_firestore_odm
 description: An ODM for Firebase Cloud Firestore (cloud_firestore).
 homepage: https://github.com/firebaseextended/firestoreodm-flutter
 repository: https://github.com/firebaseextended/firestoreodm-flutter
-version: 1.0.0-dev.87
+version: 1.0.0-dev.88
 
 false_secrets:
   - example/**

--- a/packages/cloud_firestore_odm_generator/CHANGELOG.md
+++ b/packages/cloud_firestore_odm_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-dev.89
+
+- Adds generated `set` methods with `FieldValue` parameters
+
 ## 1.0.0-dev.88 - 2024-07-08
 
 - **FEAT**: Add batch API ([#12](https://github.com/FirebaseExtended/firestoreodm-flutter/issues/12)). ([4dd8a9a8](https://github.com/FirebaseExtended/firestoreodm-flutter/commit/4dd8a9a893bf6ababa5e9d52de95bacc549ad21b))

--- a/packages/cloud_firestore_odm_generator/CHANGELOG.md
+++ b/packages/cloud_firestore_odm_generator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.0-dev.89
 
+- **Breaking**: `set` options are not a named parameter.
 - Adds generated `set` methods with `FieldValue` parameters
 
 ## 1.0.0-dev.88 - 2024-07-08

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.freezed.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.freezed.dart
@@ -12,7 +12,7 @@ part of 'freezed.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 Person _$PersonFromJson(Map<String, dynamic> json) {
   return _Person.fromJson(json);
@@ -26,8 +26,12 @@ mixin _$Person {
   @JsonKey(includeFromJson: false, includeToJson: false)
   int? get ignored => throw _privateConstructorUsedError;
 
+  /// Serializes this Person to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PersonCopyWith<Person> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -52,6 +56,8 @@ class _$PersonCopyWithImpl<$Res, $Val extends Person>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -97,6 +103,8 @@ class __$$PersonImplCopyWithImpl<$Res>
       _$PersonImpl _value, $Res Function(_$PersonImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -159,11 +167,13 @@ class _$PersonImpl implements _Person {
             (identical(other.ignored, ignored) || other.ignored == ignored));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, firstName, lastName, ignored);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PersonImplCopyWith<_$PersonImpl> get copyWith =>
@@ -194,8 +204,11 @@ abstract class _Person implements Person {
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   int? get ignored;
+
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PersonImplCopyWith<_$PersonImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -208,8 +221,12 @@ PublicRedirected _$PublicRedirectedFromJson(Map<String, dynamic> json) {
 mixin _$PublicRedirected {
   String get value => throw _privateConstructorUsedError;
 
+  /// Serializes this PublicRedirected to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PublicRedirected
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PublicRedirectedCopyWith<PublicRedirected> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -233,6 +250,8 @@ class _$PublicRedirectedCopyWithImpl<$Res, $Val extends PublicRedirected>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PublicRedirected
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -266,6 +285,8 @@ class __$$PublicRedirected2ImplCopyWithImpl<$Res>
       $Res Function(_$PublicRedirected2Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PublicRedirected
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -304,11 +325,13 @@ class _$PublicRedirected2Impl implements PublicRedirected2 {
             (identical(other.value, value) || other.value == value));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, value);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PublicRedirected
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PublicRedirected2ImplCopyWith<_$PublicRedirected2Impl> get copyWith =>
@@ -332,8 +355,11 @@ abstract class PublicRedirected2 implements PublicRedirected {
 
   @override
   String get value;
+
+  /// Create a copy of PublicRedirected
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PublicRedirected2ImplCopyWith<_$PublicRedirected2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
@@ -245,7 +245,11 @@ class _$PersonDocumentReference
         _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -1347,7 +1351,11 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
         _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
@@ -124,15 +124,49 @@ abstract class PersonDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    Person model, {
+    SetOptions? setOptions,
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    Person model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    Person model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    String firstName,
-    FieldValue firstNameFieldValue,
-    String lastName,
-    FieldValue lastNameFieldValue,
+    Object? firstName = _sentinel,
+    FieldValue? firstNameFieldValue,
+    Object? lastName = _sentinel,
+    FieldValue? lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -140,10 +174,10 @@ abstract class PersonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    String firstName,
-    FieldValue firstNameFieldValue,
-    String lastName,
-    FieldValue lastNameFieldValue,
+    Object? firstName = _sentinel,
+    FieldValue? firstNameFieldValue,
+    Object? lastName = _sentinel,
+    FieldValue? lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -151,10 +185,10 @@ abstract class PersonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    String firstName,
-    FieldValue firstNameFieldValue,
-    String lastName,
-    FieldValue lastNameFieldValue,
+    Object? firstName = _sentinel,
+    FieldValue? firstNameFieldValue,
+    Object? lastName = _sentinel,
+    FieldValue? lastNameFieldValue,
   });
 }
 
@@ -184,6 +218,57 @@ class _$PersonDocumentReference
   @override
   Future<PersonDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(PersonDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    Person model, {
+    SetOptions? setOptions,
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (firstNameFieldValue != null)
+        _$$PersonImplFieldMap['firstName']!: firstNameFieldValue,
+      if (lastNameFieldValue != null)
+        _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    Person model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (firstNameFieldValue != null)
+        _$$PersonImplFieldMap['firstName']!: firstNameFieldValue,
+      if (lastNameFieldValue != null)
+        _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    Person model, {
+    FieldValue? firstNameFieldValue,
+    FieldValue? lastNameFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (firstNameFieldValue != null)
+        _$$PersonImplFieldMap['firstName']!: firstNameFieldValue,
+      if (lastNameFieldValue != null)
+        _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -1139,13 +1224,44 @@ abstract class PublicRedirectedDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    PublicRedirected model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    PublicRedirected model, {
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    PublicRedirected model, {
+    FieldValue? valueFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    String value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -1153,8 +1269,8 @@ abstract class PublicRedirectedDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    String value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -1162,8 +1278,8 @@ abstract class PublicRedirectedDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    String value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 }
 
@@ -1194,6 +1310,48 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
   Future<PublicRedirectedDocumentSnapshot> transactionGet(
       Transaction transaction) {
     return transaction.get(reference).then(PublicRedirectedDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    PublicRedirected model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    PublicRedirected model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    PublicRedirected model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
@@ -132,8 +132,8 @@ abstract class PersonDocumentReference
   Future<void> set(
     Person model, {
     SetOptions? setOptions,
-    FieldValue? firstNameFieldValue,
-    FieldValue? lastNameFieldValue,
+    FieldValue firstNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -143,8 +143,8 @@ abstract class PersonDocumentReference
   void transactionSet(
     Transaction transaction,
     Person model, {
-    FieldValue? firstNameFieldValue,
-    FieldValue? lastNameFieldValue,
+    FieldValue firstNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -154,8 +154,8 @@ abstract class PersonDocumentReference
   void batchSet(
     WriteBatch batch,
     Person model, {
-    FieldValue? firstNameFieldValue,
-    FieldValue? lastNameFieldValue,
+    FieldValue firstNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -164,9 +164,9 @@ abstract class PersonDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     String firstName,
-    FieldValue? firstNameFieldValue,
+    FieldValue firstNameFieldValue,
     String lastName,
-    FieldValue? lastNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -175,9 +175,9 @@ abstract class PersonDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     String firstName,
-    FieldValue? firstNameFieldValue,
+    FieldValue firstNameFieldValue,
     String lastName,
-    FieldValue? lastNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -186,9 +186,9 @@ abstract class PersonDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     String firstName,
-    FieldValue? firstNameFieldValue,
+    FieldValue firstNameFieldValue,
     String lastName,
-    FieldValue? lastNameFieldValue,
+    FieldValue lastNameFieldValue,
   });
 }
 
@@ -1232,7 +1232,7 @@ abstract class PublicRedirectedDocumentReference
   Future<void> set(
     PublicRedirected model, {
     SetOptions? setOptions,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -1242,7 +1242,7 @@ abstract class PublicRedirectedDocumentReference
   void transactionSet(
     Transaction transaction,
     PublicRedirected model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -1252,7 +1252,7 @@ abstract class PublicRedirectedDocumentReference
   void batchSet(
     WriteBatch batch,
     PublicRedirected model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -1261,7 +1261,7 @@ abstract class PublicRedirectedDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     String value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -1270,7 +1270,7 @@ abstract class PublicRedirectedDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     String value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -1279,7 +1279,7 @@ abstract class PublicRedirectedDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     String value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 }
 

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
@@ -134,7 +134,7 @@ abstract class PersonDocumentReference
   /// [model] during serialization.
   Future<void> set(
     Person model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue firstNameFieldValue,
     FieldValue lastNameFieldValue,
   });
@@ -149,6 +149,7 @@ abstract class PersonDocumentReference
   void transactionSet(
     Transaction transaction,
     Person model, {
+    SetOptions? options,
     FieldValue firstNameFieldValue,
     FieldValue lastNameFieldValue,
   });
@@ -163,6 +164,7 @@ abstract class PersonDocumentReference
   void batchSet(
     WriteBatch batch,
     Person model, {
+    SetOptions? options,
     FieldValue firstNameFieldValue,
     FieldValue lastNameFieldValue,
   });
@@ -231,7 +233,7 @@ class _$PersonDocumentReference
 
   Future<void> set(
     Person model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? firstNameFieldValue,
     FieldValue? lastNameFieldValue,
   }) async {
@@ -243,12 +245,13 @@ class _$PersonDocumentReference
         _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     Person model, {
+    SetOptions? options,
     FieldValue? firstNameFieldValue,
     FieldValue? lastNameFieldValue,
   }) {
@@ -260,12 +263,13 @@ class _$PersonDocumentReference
         _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     Person model, {
+    SetOptions? options,
     FieldValue? firstNameFieldValue,
     FieldValue? lastNameFieldValue,
   }) {
@@ -277,7 +281,7 @@ class _$PersonDocumentReference
         _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -1243,7 +1247,7 @@ abstract class PublicRedirectedDocumentReference
   /// [model] during serialization.
   Future<void> set(
     PublicRedirected model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -1257,6 +1261,7 @@ abstract class PublicRedirectedDocumentReference
   void transactionSet(
     Transaction transaction,
     PublicRedirected model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -1270,6 +1275,7 @@ abstract class PublicRedirectedDocumentReference
   void batchSet(
     WriteBatch batch,
     PublicRedirected model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -1332,7 +1338,7 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
 
   Future<void> set(
     PublicRedirected model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) async {
     final json = {
@@ -1341,12 +1347,13 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
         _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     PublicRedirected model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -1355,12 +1362,13 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
         _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     PublicRedirected model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -1369,7 +1377,7 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
         _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
@@ -131,7 +131,7 @@ abstract class PersonDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     Person model, {
     SetOptions? setOptions,
@@ -145,7 +145,7 @@ abstract class PersonDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     Person model, {
@@ -159,7 +159,7 @@ abstract class PersonDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     Person model, {
@@ -1240,7 +1240,7 @@ abstract class PublicRedirectedDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     PublicRedirected model, {
     SetOptions? setOptions,
@@ -1253,7 +1253,7 @@ abstract class PublicRedirectedDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     PublicRedirected model, {
@@ -1266,7 +1266,7 @@ abstract class PublicRedirectedDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     PublicRedirected model, {

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
@@ -129,6 +129,9 @@ abstract class PersonDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     Person model, {
     SetOptions? setOptions,
@@ -140,6 +143,9 @@ abstract class PersonDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     Person model, {
@@ -151,6 +157,9 @@ abstract class PersonDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     Person model, {
@@ -1229,6 +1238,9 @@ abstract class PublicRedirectedDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     PublicRedirected model, {
     SetOptions? setOptions,
@@ -1239,6 +1251,9 @@ abstract class PublicRedirectedDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     PublicRedirected model, {
@@ -1249,6 +1264,9 @@ abstract class PublicRedirectedDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     PublicRedirected model, {

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
@@ -163,9 +163,9 @@ abstract class PersonDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? firstName = _sentinel,
+    String firstName,
     FieldValue? firstNameFieldValue,
-    Object? lastName = _sentinel,
+    String lastName,
     FieldValue? lastNameFieldValue,
   });
 
@@ -174,9 +174,9 @@ abstract class PersonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? firstName = _sentinel,
+    String firstName,
     FieldValue? firstNameFieldValue,
-    Object? lastName = _sentinel,
+    String lastName,
     FieldValue? lastNameFieldValue,
   });
 
@@ -185,9 +185,9 @@ abstract class PersonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? firstName = _sentinel,
+    String firstName,
     FieldValue? firstNameFieldValue,
-    Object? lastName = _sentinel,
+    String lastName,
     FieldValue? lastNameFieldValue,
   });
 }
@@ -1260,7 +1260,7 @@ abstract class PublicRedirectedDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? value = _sentinel,
+    String value,
     FieldValue? valueFieldValue,
   });
 
@@ -1269,7 +1269,7 @@ abstract class PublicRedirectedDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? value = _sentinel,
+    String value,
     FieldValue? valueFieldValue,
   });
 
@@ -1278,7 +1278,7 @@ abstract class PublicRedirectedDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? value = _sentinel,
+    String value,
     FieldValue? valueFieldValue,
   });
 }

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
@@ -136,7 +136,7 @@ abstract class IgnoredGetterDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     IgnoredGetter model, {
     SetOptions? setOptions,
@@ -149,7 +149,7 @@ abstract class IgnoredGetterDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     IgnoredGetter model, {
@@ -162,7 +162,7 @@ abstract class IgnoredGetterDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     IgnoredGetter model, {
@@ -1051,7 +1051,7 @@ abstract class ModelDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     Model model, {
     SetOptions? setOptions,
@@ -1064,7 +1064,7 @@ abstract class ModelDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     Model model, {
@@ -1077,7 +1077,7 @@ abstract class ModelDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     Model model, {
@@ -1946,7 +1946,7 @@ abstract class NestedDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     Nested model, {
     SetOptions? setOptions,
@@ -1971,7 +1971,7 @@ abstract class NestedDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     Nested model, {
@@ -1996,7 +1996,7 @@ abstract class NestedDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     Nested model, {
@@ -5844,7 +5844,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     OptionalJson model, {
     SetOptions? setOptions,
@@ -5857,7 +5857,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     OptionalJson model, {
@@ -5870,7 +5870,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     OptionalJson model, {
@@ -6758,7 +6758,7 @@ abstract class MixedJsonDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     MixedJson model, {
     SetOptions? setOptions,
@@ -6771,7 +6771,7 @@ abstract class MixedJsonDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     MixedJson model, {
@@ -6784,7 +6784,7 @@ abstract class MixedJsonDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     MixedJson model, {
@@ -7685,7 +7685,7 @@ abstract class RootDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     Root model, {
     SetOptions? setOptions,
@@ -7699,7 +7699,7 @@ abstract class RootDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     Root model, {
@@ -7713,7 +7713,7 @@ abstract class RootDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     Root model, {
@@ -8810,7 +8810,7 @@ abstract class SubDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     Sub model, {
     SetOptions? setOptions,
@@ -8824,7 +8824,7 @@ abstract class SubDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     Sub model, {
@@ -8838,7 +8838,7 @@ abstract class SubDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     Sub model, {
@@ -9926,7 +9926,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     AsCamelCase model, {
     SetOptions? setOptions,
@@ -9939,7 +9939,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     AsCamelCase model, {
@@ -9952,7 +9952,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     AsCamelCase model, {
@@ -10862,7 +10862,7 @@ abstract class CustomSubNameDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     CustomSubName model, {
     SetOptions? setOptions,
@@ -10875,7 +10875,7 @@ abstract class CustomSubNameDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     CustomSubName model, {
@@ -10888,7 +10888,7 @@ abstract class CustomSubNameDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     CustomSubName model, {
@@ -11801,7 +11801,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     CustomClassPrefix model, {
     SetOptions? setOptions,
@@ -11814,7 +11814,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     CustomClassPrefix model, {
@@ -11827,7 +11827,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     CustomClassPrefix model, {
@@ -12739,7 +12739,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     ExplicitPath model, {
     SetOptions? setOptions,
@@ -12752,7 +12752,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     ExplicitPath model, {
@@ -12765,7 +12765,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     ExplicitPath model, {
@@ -13676,7 +13676,7 @@ abstract class ExplicitSubPathDocumentReference
   /// document instead of overwriting.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   Future<void> set(
     ExplicitSubPath model, {
     SetOptions? setOptions,
@@ -13689,7 +13689,7 @@ abstract class ExplicitSubPathDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void transactionSet(
     Transaction transaction,
     ExplicitSubPath model, {
@@ -13702,7 +13702,7 @@ abstract class ExplicitSubPathDocumentReference
   /// [SetOptions], the provided data can be merged into the existing document.
   ///
   /// Any [FieldValue]s provided will replace the corresponding fields in the
-  /// model during serialization.
+  /// [model] during serialization.
   void batchSet(
     WriteBatch batch,
     ExplicitSubPath model, {

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
@@ -129,13 +129,44 @@ abstract class IgnoredGetterDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    IgnoredGetter model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    IgnoredGetter model, {
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    IgnoredGetter model, {
+    FieldValue? valueFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    int value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -143,8 +174,8 @@ abstract class IgnoredGetterDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    int value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -152,8 +183,8 @@ abstract class IgnoredGetterDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    int value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 }
 
@@ -184,6 +215,48 @@ class _$IgnoredGetterDocumentReference extends FirestoreDocumentReference<
   Future<IgnoredGetterDocumentSnapshot> transactionGet(
       Transaction transaction) {
     return transaction.get(reference).then(IgnoredGetterDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    IgnoredGetter model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  }) async {
+    final json = {
+      ..._$IgnoredGetterToJson(model),
+      if (valueFieldValue != null)
+        _$IgnoredGetterFieldMap['value']!: valueFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    IgnoredGetter model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ..._$IgnoredGetterToJson(model),
+      if (valueFieldValue != null)
+        _$IgnoredGetterFieldMap['value']!: valueFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    IgnoredGetter model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ..._$IgnoredGetterToJson(model),
+      if (valueFieldValue != null)
+        _$IgnoredGetterFieldMap['value']!: valueFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -962,13 +1035,44 @@ abstract class ModelDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    Model model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    Model model, {
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    Model model, {
+    FieldValue? valueFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    String value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -976,8 +1080,8 @@ abstract class ModelDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    String value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -985,8 +1089,8 @@ abstract class ModelDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    String value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 }
 
@@ -1016,6 +1120,45 @@ class _$ModelDocumentReference
   @override
   Future<ModelDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(ModelDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    Model model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  }) async {
+    final json = {
+      ..._$ModelToJson(model),
+      if (valueFieldValue != null) _$ModelFieldMap['value']!: valueFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    Model model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ..._$ModelToJson(model),
+      if (valueFieldValue != null) _$ModelFieldMap['value']!: valueFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    Model model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ..._$ModelToJson(model),
+      if (valueFieldValue != null) _$ModelFieldMap['value']!: valueFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -1778,37 +1921,104 @@ abstract class NestedDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    Nested model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+    FieldValue? simpleFieldValue,
+    FieldValue? valueListFieldValue,
+    FieldValue? boolListFieldValue,
+    FieldValue? stringListFieldValue,
+    FieldValue? numListFieldValue,
+    FieldValue? objectListFieldValue,
+    FieldValue? dynamicListFieldValue,
+    FieldValue? boolSetFieldValue,
+    FieldValue? enumValueFieldValue,
+    FieldValue? nullableEnumValueFieldValue,
+    FieldValue? enumListFieldValue,
+    FieldValue? nullableEnumListFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    Nested model, {
+    FieldValue? valueFieldValue,
+    FieldValue? simpleFieldValue,
+    FieldValue? valueListFieldValue,
+    FieldValue? boolListFieldValue,
+    FieldValue? stringListFieldValue,
+    FieldValue? numListFieldValue,
+    FieldValue? objectListFieldValue,
+    FieldValue? dynamicListFieldValue,
+    FieldValue? boolSetFieldValue,
+    FieldValue? enumValueFieldValue,
+    FieldValue? nullableEnumValueFieldValue,
+    FieldValue? enumListFieldValue,
+    FieldValue? nullableEnumListFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    Nested model, {
+    FieldValue? valueFieldValue,
+    FieldValue? simpleFieldValue,
+    FieldValue? valueListFieldValue,
+    FieldValue? boolListFieldValue,
+    FieldValue? stringListFieldValue,
+    FieldValue? numListFieldValue,
+    FieldValue? objectListFieldValue,
+    FieldValue? dynamicListFieldValue,
+    FieldValue? boolSetFieldValue,
+    FieldValue? enumValueFieldValue,
+    FieldValue? nullableEnumValueFieldValue,
+    FieldValue? enumListFieldValue,
+    FieldValue? nullableEnumListFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Nested? value,
-    FieldValue valueFieldValue,
-    int? simple,
-    FieldValue simpleFieldValue,
-    List<Nested>? valueList,
-    FieldValue valueListFieldValue,
-    List<bool>? boolList,
-    FieldValue boolListFieldValue,
-    List<String>? stringList,
-    FieldValue stringListFieldValue,
-    List<num>? numList,
-    FieldValue numListFieldValue,
-    List<Object?>? objectList,
-    FieldValue objectListFieldValue,
-    List<dynamic>? dynamicList,
-    FieldValue dynamicListFieldValue,
-    Set<bool>? boolSet,
-    FieldValue boolSetFieldValue,
-    TestEnum enumValue,
-    FieldValue enumValueFieldValue,
-    TestEnum? nullableEnumValue,
-    FieldValue nullableEnumValueFieldValue,
-    List<TestEnum> enumList,
-    FieldValue enumListFieldValue,
-    List<TestEnum>? nullableEnumList,
-    FieldValue nullableEnumListFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
+    Object? simple = _sentinel,
+    FieldValue? simpleFieldValue,
+    Object? valueList = _sentinel,
+    FieldValue? valueListFieldValue,
+    Object? boolList = _sentinel,
+    FieldValue? boolListFieldValue,
+    Object? stringList = _sentinel,
+    FieldValue? stringListFieldValue,
+    Object? numList = _sentinel,
+    FieldValue? numListFieldValue,
+    Object? objectList = _sentinel,
+    FieldValue? objectListFieldValue,
+    Object? dynamicList = _sentinel,
+    FieldValue? dynamicListFieldValue,
+    Object? boolSet = _sentinel,
+    FieldValue? boolSetFieldValue,
+    Object? enumValue = _sentinel,
+    FieldValue? enumValueFieldValue,
+    Object? nullableEnumValue = _sentinel,
+    FieldValue? nullableEnumValueFieldValue,
+    Object? enumList = _sentinel,
+    FieldValue? enumListFieldValue,
+    Object? nullableEnumList = _sentinel,
+    FieldValue? nullableEnumListFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -1816,32 +2026,32 @@ abstract class NestedDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Nested? value,
-    FieldValue valueFieldValue,
-    int? simple,
-    FieldValue simpleFieldValue,
-    List<Nested>? valueList,
-    FieldValue valueListFieldValue,
-    List<bool>? boolList,
-    FieldValue boolListFieldValue,
-    List<String>? stringList,
-    FieldValue stringListFieldValue,
-    List<num>? numList,
-    FieldValue numListFieldValue,
-    List<Object?>? objectList,
-    FieldValue objectListFieldValue,
-    List<dynamic>? dynamicList,
-    FieldValue dynamicListFieldValue,
-    Set<bool>? boolSet,
-    FieldValue boolSetFieldValue,
-    TestEnum enumValue,
-    FieldValue enumValueFieldValue,
-    TestEnum? nullableEnumValue,
-    FieldValue nullableEnumValueFieldValue,
-    List<TestEnum> enumList,
-    FieldValue enumListFieldValue,
-    List<TestEnum>? nullableEnumList,
-    FieldValue nullableEnumListFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
+    Object? simple = _sentinel,
+    FieldValue? simpleFieldValue,
+    Object? valueList = _sentinel,
+    FieldValue? valueListFieldValue,
+    Object? boolList = _sentinel,
+    FieldValue? boolListFieldValue,
+    Object? stringList = _sentinel,
+    FieldValue? stringListFieldValue,
+    Object? numList = _sentinel,
+    FieldValue? numListFieldValue,
+    Object? objectList = _sentinel,
+    FieldValue? objectListFieldValue,
+    Object? dynamicList = _sentinel,
+    FieldValue? dynamicListFieldValue,
+    Object? boolSet = _sentinel,
+    FieldValue? boolSetFieldValue,
+    Object? enumValue = _sentinel,
+    FieldValue? enumValueFieldValue,
+    Object? nullableEnumValue = _sentinel,
+    FieldValue? nullableEnumValueFieldValue,
+    Object? enumList = _sentinel,
+    FieldValue? enumListFieldValue,
+    Object? nullableEnumList = _sentinel,
+    FieldValue? nullableEnumListFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -1849,32 +2059,32 @@ abstract class NestedDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Nested? value,
-    FieldValue valueFieldValue,
-    int? simple,
-    FieldValue simpleFieldValue,
-    List<Nested>? valueList,
-    FieldValue valueListFieldValue,
-    List<bool>? boolList,
-    FieldValue boolListFieldValue,
-    List<String>? stringList,
-    FieldValue stringListFieldValue,
-    List<num>? numList,
-    FieldValue numListFieldValue,
-    List<Object?>? objectList,
-    FieldValue objectListFieldValue,
-    List<dynamic>? dynamicList,
-    FieldValue dynamicListFieldValue,
-    Set<bool>? boolSet,
-    FieldValue boolSetFieldValue,
-    TestEnum enumValue,
-    FieldValue enumValueFieldValue,
-    TestEnum? nullableEnumValue,
-    FieldValue nullableEnumValueFieldValue,
-    List<TestEnum> enumList,
-    FieldValue enumListFieldValue,
-    List<TestEnum>? nullableEnumList,
-    FieldValue nullableEnumListFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
+    Object? simple = _sentinel,
+    FieldValue? simpleFieldValue,
+    Object? valueList = _sentinel,
+    FieldValue? valueListFieldValue,
+    Object? boolList = _sentinel,
+    FieldValue? boolListFieldValue,
+    Object? stringList = _sentinel,
+    FieldValue? stringListFieldValue,
+    Object? numList = _sentinel,
+    FieldValue? numListFieldValue,
+    Object? objectList = _sentinel,
+    FieldValue? objectListFieldValue,
+    Object? dynamicList = _sentinel,
+    FieldValue? dynamicListFieldValue,
+    Object? boolSet = _sentinel,
+    FieldValue? boolSetFieldValue,
+    Object? enumValue = _sentinel,
+    FieldValue? enumValueFieldValue,
+    Object? nullableEnumValue = _sentinel,
+    FieldValue? nullableEnumValueFieldValue,
+    Object? enumList = _sentinel,
+    FieldValue? enumListFieldValue,
+    Object? nullableEnumList = _sentinel,
+    FieldValue? nullableEnumListFieldValue,
   });
 }
 
@@ -1904,6 +2114,153 @@ class _$NestedDocumentReference
   @override
   Future<NestedDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(NestedDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    Nested model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+    FieldValue? simpleFieldValue,
+    FieldValue? valueListFieldValue,
+    FieldValue? boolListFieldValue,
+    FieldValue? stringListFieldValue,
+    FieldValue? numListFieldValue,
+    FieldValue? objectListFieldValue,
+    FieldValue? dynamicListFieldValue,
+    FieldValue? boolSetFieldValue,
+    FieldValue? enumValueFieldValue,
+    FieldValue? nullableEnumValueFieldValue,
+    FieldValue? enumListFieldValue,
+    FieldValue? nullableEnumListFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null) _$NestedFieldMap['value']!: valueFieldValue,
+      if (simpleFieldValue != null)
+        _$NestedFieldMap['simple']!: simpleFieldValue,
+      if (valueListFieldValue != null)
+        _$NestedFieldMap['valueList']!: valueListFieldValue,
+      if (boolListFieldValue != null)
+        _$NestedFieldMap['boolList']!: boolListFieldValue,
+      if (stringListFieldValue != null)
+        _$NestedFieldMap['stringList']!: stringListFieldValue,
+      if (numListFieldValue != null)
+        _$NestedFieldMap['numList']!: numListFieldValue,
+      if (objectListFieldValue != null)
+        _$NestedFieldMap['objectList']!: objectListFieldValue,
+      if (dynamicListFieldValue != null)
+        _$NestedFieldMap['dynamicList']!: dynamicListFieldValue,
+      if (boolSetFieldValue != null)
+        _$NestedFieldMap['boolSet']!: boolSetFieldValue,
+      if (enumValueFieldValue != null)
+        _$NestedFieldMap['enumValue']!: enumValueFieldValue,
+      if (nullableEnumValueFieldValue != null)
+        _$NestedFieldMap['nullableEnumValue']!: nullableEnumValueFieldValue,
+      if (enumListFieldValue != null)
+        _$NestedFieldMap['enumList']!: enumListFieldValue,
+      if (nullableEnumListFieldValue != null)
+        _$NestedFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    Nested model, {
+    FieldValue? valueFieldValue,
+    FieldValue? simpleFieldValue,
+    FieldValue? valueListFieldValue,
+    FieldValue? boolListFieldValue,
+    FieldValue? stringListFieldValue,
+    FieldValue? numListFieldValue,
+    FieldValue? objectListFieldValue,
+    FieldValue? dynamicListFieldValue,
+    FieldValue? boolSetFieldValue,
+    FieldValue? enumValueFieldValue,
+    FieldValue? nullableEnumValueFieldValue,
+    FieldValue? enumListFieldValue,
+    FieldValue? nullableEnumListFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null) _$NestedFieldMap['value']!: valueFieldValue,
+      if (simpleFieldValue != null)
+        _$NestedFieldMap['simple']!: simpleFieldValue,
+      if (valueListFieldValue != null)
+        _$NestedFieldMap['valueList']!: valueListFieldValue,
+      if (boolListFieldValue != null)
+        _$NestedFieldMap['boolList']!: boolListFieldValue,
+      if (stringListFieldValue != null)
+        _$NestedFieldMap['stringList']!: stringListFieldValue,
+      if (numListFieldValue != null)
+        _$NestedFieldMap['numList']!: numListFieldValue,
+      if (objectListFieldValue != null)
+        _$NestedFieldMap['objectList']!: objectListFieldValue,
+      if (dynamicListFieldValue != null)
+        _$NestedFieldMap['dynamicList']!: dynamicListFieldValue,
+      if (boolSetFieldValue != null)
+        _$NestedFieldMap['boolSet']!: boolSetFieldValue,
+      if (enumValueFieldValue != null)
+        _$NestedFieldMap['enumValue']!: enumValueFieldValue,
+      if (nullableEnumValueFieldValue != null)
+        _$NestedFieldMap['nullableEnumValue']!: nullableEnumValueFieldValue,
+      if (enumListFieldValue != null)
+        _$NestedFieldMap['enumList']!: enumListFieldValue,
+      if (nullableEnumListFieldValue != null)
+        _$NestedFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    Nested model, {
+    FieldValue? valueFieldValue,
+    FieldValue? simpleFieldValue,
+    FieldValue? valueListFieldValue,
+    FieldValue? boolListFieldValue,
+    FieldValue? stringListFieldValue,
+    FieldValue? numListFieldValue,
+    FieldValue? objectListFieldValue,
+    FieldValue? dynamicListFieldValue,
+    FieldValue? boolSetFieldValue,
+    FieldValue? enumValueFieldValue,
+    FieldValue? nullableEnumValueFieldValue,
+    FieldValue? enumListFieldValue,
+    FieldValue? nullableEnumListFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null) _$NestedFieldMap['value']!: valueFieldValue,
+      if (simpleFieldValue != null)
+        _$NestedFieldMap['simple']!: simpleFieldValue,
+      if (valueListFieldValue != null)
+        _$NestedFieldMap['valueList']!: valueListFieldValue,
+      if (boolListFieldValue != null)
+        _$NestedFieldMap['boolList']!: boolListFieldValue,
+      if (stringListFieldValue != null)
+        _$NestedFieldMap['stringList']!: stringListFieldValue,
+      if (numListFieldValue != null)
+        _$NestedFieldMap['numList']!: numListFieldValue,
+      if (objectListFieldValue != null)
+        _$NestedFieldMap['objectList']!: objectListFieldValue,
+      if (dynamicListFieldValue != null)
+        _$NestedFieldMap['dynamicList']!: dynamicListFieldValue,
+      if (boolSetFieldValue != null)
+        _$NestedFieldMap['boolSet']!: boolSetFieldValue,
+      if (enumValueFieldValue != null)
+        _$NestedFieldMap['enumValue']!: enumValueFieldValue,
+      if (nullableEnumValueFieldValue != null)
+        _$NestedFieldMap['nullableEnumValue']!: nullableEnumValueFieldValue,
+      if (enumListFieldValue != null)
+        _$NestedFieldMap['enumList']!: enumListFieldValue,
+      if (nullableEnumListFieldValue != null)
+        _$NestedFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -5453,13 +5810,44 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    OptionalJson model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    OptionalJson model, {
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    OptionalJson model, {
+    FieldValue? valueFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    int value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -5467,8 +5855,8 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    int value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -5476,8 +5864,8 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    int value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 }
 
@@ -5507,6 +5895,48 @@ class _$OptionalJsonDocumentReference extends FirestoreDocumentReference<
   @override
   Future<OptionalJsonDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(OptionalJsonDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    OptionalJson model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  }) async {
+    final json = {
+      ..._$OptionalJsonToJson(model),
+      if (valueFieldValue != null)
+        _$OptionalJsonFieldMap['value']!: valueFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    OptionalJson model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ..._$OptionalJsonToJson(model),
+      if (valueFieldValue != null)
+        _$OptionalJsonFieldMap['value']!: valueFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    OptionalJson model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ..._$OptionalJsonToJson(model),
+      if (valueFieldValue != null)
+        _$OptionalJsonFieldMap['value']!: valueFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -6285,13 +6715,44 @@ abstract class MixedJsonDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    MixedJson model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    MixedJson model, {
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    MixedJson model, {
+    FieldValue? valueFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    int value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -6299,8 +6760,8 @@ abstract class MixedJsonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    int value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -6308,8 +6769,8 @@ abstract class MixedJsonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    int value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 }
 
@@ -6339,6 +6800,48 @@ class _$MixedJsonDocumentReference
   @override
   Future<MixedJsonDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(MixedJsonDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    MixedJson model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$MixedJsonFieldMap['value']!: valueFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    MixedJson model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$MixedJsonFieldMap['value']!: valueFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    MixedJson model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$MixedJsonFieldMap['value']!: valueFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -7130,15 +7633,49 @@ abstract class RootDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    Root model, {
+    SetOptions? setOptions,
+    FieldValue? nonNullableFieldValue,
+    FieldValue? nullableFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    Root model, {
+    FieldValue? nonNullableFieldValue,
+    FieldValue? nullableFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    Root model, {
+    FieldValue? nonNullableFieldValue,
+    FieldValue? nullableFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    String nonNullable,
-    FieldValue nonNullableFieldValue,
-    int? nullable,
-    FieldValue nullableFieldValue,
+    Object? nonNullable = _sentinel,
+    FieldValue? nonNullableFieldValue,
+    Object? nullable = _sentinel,
+    FieldValue? nullableFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -7146,10 +7683,10 @@ abstract class RootDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    String nonNullable,
-    FieldValue nonNullableFieldValue,
-    int? nullable,
-    FieldValue nullableFieldValue,
+    Object? nonNullable = _sentinel,
+    FieldValue? nonNullableFieldValue,
+    Object? nullable = _sentinel,
+    FieldValue? nullableFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -7157,10 +7694,10 @@ abstract class RootDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    String nonNullable,
-    FieldValue nonNullableFieldValue,
-    int? nullable,
-    FieldValue nullableFieldValue,
+    Object? nonNullable = _sentinel,
+    FieldValue? nonNullableFieldValue,
+    Object? nullable = _sentinel,
+    FieldValue? nullableFieldValue,
   });
 }
 
@@ -7209,6 +7746,57 @@ class _$RootDocumentReference
   @override
   Future<RootDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(RootDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    Root model, {
+    SetOptions? setOptions,
+    FieldValue? nonNullableFieldValue,
+    FieldValue? nullableFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (nonNullableFieldValue != null)
+        _$RootFieldMap['nonNullable']!: nonNullableFieldValue,
+      if (nullableFieldValue != null)
+        _$RootFieldMap['nullable']!: nullableFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    Root model, {
+    FieldValue? nonNullableFieldValue,
+    FieldValue? nullableFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (nonNullableFieldValue != null)
+        _$RootFieldMap['nonNullable']!: nonNullableFieldValue,
+      if (nullableFieldValue != null)
+        _$RootFieldMap['nullable']!: nullableFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    Root model, {
+    FieldValue? nonNullableFieldValue,
+    FieldValue? nullableFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (nonNullableFieldValue != null)
+        _$RootFieldMap['nonNullable']!: nonNullableFieldValue,
+      if (nullableFieldValue != null)
+        _$RootFieldMap['nullable']!: nullableFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -8161,15 +8749,49 @@ abstract class SubDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    Sub model, {
+    SetOptions? setOptions,
+    FieldValue? nonNullableFieldValue,
+    FieldValue? nullableFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    Sub model, {
+    FieldValue? nonNullableFieldValue,
+    FieldValue? nullableFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    Sub model, {
+    FieldValue? nonNullableFieldValue,
+    FieldValue? nullableFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    String nonNullable,
-    FieldValue nonNullableFieldValue,
-    int? nullable,
-    FieldValue nullableFieldValue,
+    Object? nonNullable = _sentinel,
+    FieldValue? nonNullableFieldValue,
+    Object? nullable = _sentinel,
+    FieldValue? nullableFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -8177,10 +8799,10 @@ abstract class SubDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    String nonNullable,
-    FieldValue nonNullableFieldValue,
-    int? nullable,
-    FieldValue nullableFieldValue,
+    Object? nonNullable = _sentinel,
+    FieldValue? nonNullableFieldValue,
+    Object? nullable = _sentinel,
+    FieldValue? nullableFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -8188,10 +8810,10 @@ abstract class SubDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    String nonNullable,
-    FieldValue nonNullableFieldValue,
-    int? nullable,
-    FieldValue nullableFieldValue,
+    Object? nonNullable = _sentinel,
+    FieldValue? nonNullableFieldValue,
+    Object? nullable = _sentinel,
+    FieldValue? nullableFieldValue,
   });
 }
 
@@ -8226,6 +8848,57 @@ class _$SubDocumentReference
   @override
   Future<SubDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(SubDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    Sub model, {
+    SetOptions? setOptions,
+    FieldValue? nonNullableFieldValue,
+    FieldValue? nullableFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (nonNullableFieldValue != null)
+        _$SubFieldMap['nonNullable']!: nonNullableFieldValue,
+      if (nullableFieldValue != null)
+        _$SubFieldMap['nullable']!: nullableFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    Sub model, {
+    FieldValue? nonNullableFieldValue,
+    FieldValue? nullableFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (nonNullableFieldValue != null)
+        _$SubFieldMap['nonNullable']!: nonNullableFieldValue,
+      if (nullableFieldValue != null)
+        _$SubFieldMap['nullable']!: nullableFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    Sub model, {
+    FieldValue? nonNullableFieldValue,
+    FieldValue? nullableFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (nonNullableFieldValue != null)
+        _$SubFieldMap['nonNullable']!: nonNullableFieldValue,
+      if (nullableFieldValue != null)
+        _$SubFieldMap['nullable']!: nullableFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -9183,13 +9856,44 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    AsCamelCase model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    AsCamelCase model, {
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    AsCamelCase model, {
+    FieldValue? valueFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -9197,8 +9901,8 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -9206,8 +9910,8 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 }
 
@@ -9242,6 +9946,48 @@ class _$AsCamelCaseDocumentReference
   @override
   Future<AsCamelCaseDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(AsCamelCaseDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    AsCamelCase model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$AsCamelCaseFieldMap['value']!: valueFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    AsCamelCase model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$AsCamelCaseFieldMap['value']!: valueFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    AsCamelCase model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$AsCamelCaseFieldMap['value']!: valueFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -10037,13 +10783,44 @@ abstract class CustomSubNameDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    CustomSubName model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    CustomSubName model, {
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    CustomSubName model, {
+    FieldValue? valueFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -10051,8 +10828,8 @@ abstract class CustomSubNameDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -10060,8 +10837,8 @@ abstract class CustomSubNameDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 }
 
@@ -10097,6 +10874,48 @@ class _$CustomSubNameDocumentReference extends FirestoreDocumentReference<
   Future<CustomSubNameDocumentSnapshot> transactionGet(
       Transaction transaction) {
     return transaction.get(reference).then(CustomSubNameDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    CustomSubName model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$CustomSubNameFieldMap['value']!: valueFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    CustomSubName model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$CustomSubNameFieldMap['value']!: valueFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    CustomSubName model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$CustomSubNameFieldMap['value']!: valueFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -10894,13 +11713,44 @@ abstract class ThisIsACustomPrefixDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    CustomClassPrefix model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    CustomClassPrefix model, {
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    CustomClassPrefix model, {
+    FieldValue? valueFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -10908,8 +11758,8 @@ abstract class ThisIsACustomPrefixDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -10917,8 +11767,8 @@ abstract class ThisIsACustomPrefixDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 }
 
@@ -10956,6 +11806,48 @@ class _$ThisIsACustomPrefixDocumentReference extends FirestoreDocumentReference<
     return transaction
         .get(reference)
         .then(ThisIsACustomPrefixDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    CustomClassPrefix model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$CustomClassPrefixFieldMap['value']!: valueFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    CustomClassPrefix model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$CustomClassPrefixFieldMap['value']!: valueFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    CustomClassPrefix model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$CustomClassPrefixFieldMap['value']!: valueFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -11750,13 +12642,44 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    ExplicitPath model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    ExplicitPath model, {
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    ExplicitPath model, {
+    FieldValue? valueFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -11764,8 +12687,8 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -11773,8 +12696,8 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 }
 
@@ -11809,6 +12732,48 @@ class _$ExplicitPathDocumentReference extends FirestoreDocumentReference<
   @override
   Future<ExplicitPathDocumentSnapshot> transactionGet(Transaction transaction) {
     return transaction.get(reference).then(ExplicitPathDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    ExplicitPath model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$ExplicitPathFieldMap['value']!: valueFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    ExplicitPath model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$ExplicitPathFieldMap['value']!: valueFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    ExplicitPath model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$ExplicitPathFieldMap['value']!: valueFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -12605,13 +13570,44 @@ abstract class ExplicitSubPathDocumentReference
   @override
   Future<void> delete();
 
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data can be merged into an existing
+  /// document instead of overwriting.
+  Future<void> set(
+    ExplicitSubPath model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the transaction API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void transactionSet(
+    Transaction transaction,
+    ExplicitSubPath model, {
+    FieldValue? valueFieldValue,
+  });
+
+  /// Writes to the document using the batch API.
+  ///
+  /// If the document does not exist yet, it will be created. If you pass
+  /// [SetOptions], the provided data can be merged into the existing document.
+  void batchSet(
+    WriteBatch batch,
+    ExplicitSubPath model, {
+    FieldValue? valueFieldValue,
+  });
+
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -12619,8 +13615,8 @@ abstract class ExplicitSubPathDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -12628,8 +13624,8 @@ abstract class ExplicitSubPathDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    num value,
-    FieldValue valueFieldValue,
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
   });
 }
 
@@ -12665,6 +13661,48 @@ class _$ExplicitSubPathDocumentReference extends FirestoreDocumentReference<
   Future<ExplicitSubPathDocumentSnapshot> transactionGet(
       Transaction transaction) {
     return transaction.get(reference).then(ExplicitSubPathDocumentSnapshot._);
+  }
+
+  Future<void> set(
+    ExplicitSubPath model, {
+    SetOptions? setOptions,
+    FieldValue? valueFieldValue,
+  }) async {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$ExplicitSubPathFieldMap['value']!: valueFieldValue,
+    };
+
+    return (reference as DocumentReference).set(json);
+  }
+
+  void transactionSet(
+    Transaction transaction,
+    ExplicitSubPath model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$ExplicitSubPathFieldMap['value']!: valueFieldValue,
+    };
+
+    transaction.set(reference, json);
+  }
+
+  void batchSet(
+    WriteBatch batch,
+    ExplicitSubPath model, {
+    FieldValue? valueFieldValue,
+  }) {
+    final json = {
+      ...model.toJson(),
+      if (valueFieldValue != null)
+        _$ExplicitSubPathFieldMap['value']!: valueFieldValue,
+    };
+
+    batch.set(reference, json);
   }
 
   Future<void> update({
@@ -13356,7 +14394,7 @@ void _$assertMinValidation(MinValidation instance) {
 
 IgnoredGetter _$IgnoredGetterFromJson(Map<String, dynamic> json) =>
     IgnoredGetter(
-      json['value'] as int,
+      (json['value'] as num).toInt(),
     );
 
 const _$IgnoredGetterFieldMap = <String, String>{
@@ -13400,7 +14438,7 @@ Nested _$NestedFromJson(Map<String, dynamic> json) => Nested(
       value: json['value'] == null
           ? null
           : Nested.fromJson(json['value'] as Map<String, dynamic>),
-      simple: json['simple'] as int?,
+      simple: (json['simple'] as num?)?.toInt(),
       valueList: (json['valueList'] as List<dynamic>?)
           ?.map((e) => Nested.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -13510,7 +14548,7 @@ Map<String, dynamic> _$EmptyModelToJson(EmptyModel instance) =>
 
 MinValidation _$MinValidationFromJson(Map<String, dynamic> json) =>
     MinValidation(
-      json['intNbr'] as int,
+      (json['intNbr'] as num).toInt(),
       (json['doubleNbr'] as num).toDouble(),
       json['numNbr'] as num,
     );
@@ -13540,7 +14578,7 @@ Map<String, dynamic> _$MinValidationToJson(MinValidation instance) =>
 
 Root _$RootFromJson(Map<String, dynamic> json) => Root(
       json['nonNullable'] as String,
-      json['nullable'] as int?,
+      (json['nullable'] as num?)?.toInt(),
     );
 
 const _$RootFieldMap = <String, String>{
@@ -13562,7 +14600,7 @@ Map<String, dynamic> _$RootToJson(Root instance) => <String, dynamic>{
     };
 
 OptionalJson _$OptionalJsonFromJson(Map<String, dynamic> json) => OptionalJson(
-      json['value'] as int,
+      (json['value'] as num).toInt(),
     );
 
 const _$OptionalJsonFieldMap = <String, String>{
@@ -13581,7 +14619,7 @@ Map<String, dynamic> _$OptionalJsonToJson(OptionalJson instance) =>
     };
 
 MixedJson _$MixedJsonFromJson(Map<String, dynamic> json) => MixedJson(
-      json['value'] as int,
+      (json['value'] as num).toInt(),
     );
 
 const _$MixedJsonFieldMap = <String, String>{
@@ -13600,7 +14638,7 @@ Map<String, dynamic> _$MixedJsonToJson(MixedJson instance) => <String, dynamic>{
 
 Sub _$SubFromJson(Map<String, dynamic> json) => Sub(
       json['nonNullable'] as String,
-      json['nullable'] as int?,
+      (json['nullable'] as num?)?.toInt(),
     );
 
 const _$SubFieldMap = <String, String>{

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
@@ -134,6 +134,9 @@ abstract class IgnoredGetterDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     IgnoredGetter model, {
     SetOptions? setOptions,
@@ -144,6 +147,9 @@ abstract class IgnoredGetterDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     IgnoredGetter model, {
@@ -154,6 +160,9 @@ abstract class IgnoredGetterDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     IgnoredGetter model, {
@@ -1040,6 +1049,9 @@ abstract class ModelDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     Model model, {
     SetOptions? setOptions,
@@ -1050,6 +1062,9 @@ abstract class ModelDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     Model model, {
@@ -1060,6 +1075,9 @@ abstract class ModelDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     Model model, {
@@ -1926,6 +1944,9 @@ abstract class NestedDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     Nested model, {
     SetOptions? setOptions,
@@ -1948,6 +1969,9 @@ abstract class NestedDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     Nested model, {
@@ -1970,6 +1994,9 @@ abstract class NestedDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     Nested model, {
@@ -5815,6 +5842,9 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     OptionalJson model, {
     SetOptions? setOptions,
@@ -5825,6 +5855,9 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     OptionalJson model, {
@@ -5835,6 +5868,9 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     OptionalJson model, {
@@ -6720,6 +6756,9 @@ abstract class MixedJsonDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     MixedJson model, {
     SetOptions? setOptions,
@@ -6730,6 +6769,9 @@ abstract class MixedJsonDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     MixedJson model, {
@@ -6740,6 +6782,9 @@ abstract class MixedJsonDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     MixedJson model, {
@@ -7638,6 +7683,9 @@ abstract class RootDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     Root model, {
     SetOptions? setOptions,
@@ -7649,6 +7697,9 @@ abstract class RootDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     Root model, {
@@ -7660,6 +7711,9 @@ abstract class RootDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     Root model, {
@@ -8754,6 +8808,9 @@ abstract class SubDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     Sub model, {
     SetOptions? setOptions,
@@ -8765,6 +8822,9 @@ abstract class SubDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     Sub model, {
@@ -8776,6 +8836,9 @@ abstract class SubDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     Sub model, {
@@ -9861,6 +9924,9 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     AsCamelCase model, {
     SetOptions? setOptions,
@@ -9871,6 +9937,9 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     AsCamelCase model, {
@@ -9881,6 +9950,9 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     AsCamelCase model, {
@@ -10788,6 +10860,9 @@ abstract class CustomSubNameDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     CustomSubName model, {
     SetOptions? setOptions,
@@ -10798,6 +10873,9 @@ abstract class CustomSubNameDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     CustomSubName model, {
@@ -10808,6 +10886,9 @@ abstract class CustomSubNameDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     CustomSubName model, {
@@ -11718,6 +11799,9 @@ abstract class ThisIsACustomPrefixDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     CustomClassPrefix model, {
     SetOptions? setOptions,
@@ -11728,6 +11812,9 @@ abstract class ThisIsACustomPrefixDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     CustomClassPrefix model, {
@@ -11738,6 +11825,9 @@ abstract class ThisIsACustomPrefixDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     CustomClassPrefix model, {
@@ -12647,6 +12737,9 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     ExplicitPath model, {
     SetOptions? setOptions,
@@ -12657,6 +12750,9 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     ExplicitPath model, {
@@ -12667,6 +12763,9 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     ExplicitPath model, {
@@ -13575,6 +13674,9 @@ abstract class ExplicitSubPathDocumentReference
   ///
   /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   Future<void> set(
     ExplicitSubPath model, {
     SetOptions? setOptions,
@@ -13585,6 +13687,9 @@ abstract class ExplicitSubPathDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void transactionSet(
     Transaction transaction,
     ExplicitSubPath model, {
@@ -13595,6 +13700,9 @@ abstract class ExplicitSubPathDocumentReference
   ///
   /// If the document does not exist yet, it will be created. If you pass
   /// [SetOptions], the provided data can be merged into the existing document.
+  ///
+  /// Any [FieldValue]s provided will replace the corresponding fields in the
+  /// model during serialization.
   void batchSet(
     WriteBatch batch,
     ExplicitSubPath model, {

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
@@ -239,7 +239,11 @@ class _$IgnoredGetterDocumentReference extends FirestoreDocumentReference<
         _$IgnoredGetterFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -1156,7 +1160,11 @@ class _$ModelDocumentReference
       if (valueFieldValue != null) _$ModelFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -2199,7 +2207,11 @@ class _$NestedDocumentReference
         _$NestedFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -5958,7 +5970,11 @@ class _$OptionalJsonDocumentReference extends FirestoreDocumentReference<
         _$OptionalJsonFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -6876,7 +6892,11 @@ class _$MixedJsonDocumentReference
         _$MixedJsonFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -7838,7 +7858,11 @@ class _$RootDocumentReference
         _$RootFieldMap['nullable']!: nullableFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -8953,7 +8977,11 @@ class _$SubDocumentReference
         _$SubFieldMap['nullable']!: nullableFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -10061,7 +10089,11 @@ class _$AsCamelCaseDocumentReference
         _$AsCamelCaseFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -11002,7 +11034,11 @@ class _$CustomSubNameDocumentReference extends FirestoreDocumentReference<
         _$CustomSubNameFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -11947,7 +11983,11 @@ class _$ThisIsACustomPrefixDocumentReference extends FirestoreDocumentReference<
         _$CustomClassPrefixFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -12886,7 +12926,11 @@ class _$ExplicitPathDocumentReference extends FirestoreDocumentReference<
         _$ExplicitPathFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(
@@ -13828,7 +13872,11 @@ class _$ExplicitSubPathDocumentReference extends FirestoreDocumentReference<
         _$ExplicitSubPathFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+    return castedReference.set(json, options);
   }
 
   void transactionSet(

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
@@ -137,7 +137,7 @@ abstract class IgnoredGetterDocumentReference
   Future<void> set(
     IgnoredGetter model, {
     SetOptions? setOptions,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -147,7 +147,7 @@ abstract class IgnoredGetterDocumentReference
   void transactionSet(
     Transaction transaction,
     IgnoredGetter model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -157,7 +157,7 @@ abstract class IgnoredGetterDocumentReference
   void batchSet(
     WriteBatch batch,
     IgnoredGetter model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -166,7 +166,7 @@ abstract class IgnoredGetterDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     int value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -175,7 +175,7 @@ abstract class IgnoredGetterDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     int value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -184,7 +184,7 @@ abstract class IgnoredGetterDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     int value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 }
 
@@ -1043,7 +1043,7 @@ abstract class ModelDocumentReference
   Future<void> set(
     Model model, {
     SetOptions? setOptions,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -1053,7 +1053,7 @@ abstract class ModelDocumentReference
   void transactionSet(
     Transaction transaction,
     Model model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -1063,7 +1063,7 @@ abstract class ModelDocumentReference
   void batchSet(
     WriteBatch batch,
     Model model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -1072,7 +1072,7 @@ abstract class ModelDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     String value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -1081,7 +1081,7 @@ abstract class ModelDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     String value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -1090,7 +1090,7 @@ abstract class ModelDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     String value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 }
 
@@ -1929,19 +1929,19 @@ abstract class NestedDocumentReference
   Future<void> set(
     Nested model, {
     SetOptions? setOptions,
-    FieldValue? valueFieldValue,
-    FieldValue? simpleFieldValue,
-    FieldValue? valueListFieldValue,
-    FieldValue? boolListFieldValue,
-    FieldValue? stringListFieldValue,
-    FieldValue? numListFieldValue,
-    FieldValue? objectListFieldValue,
-    FieldValue? dynamicListFieldValue,
-    FieldValue? boolSetFieldValue,
-    FieldValue? enumValueFieldValue,
-    FieldValue? nullableEnumValueFieldValue,
-    FieldValue? enumListFieldValue,
-    FieldValue? nullableEnumListFieldValue,
+    FieldValue valueFieldValue,
+    FieldValue simpleFieldValue,
+    FieldValue valueListFieldValue,
+    FieldValue boolListFieldValue,
+    FieldValue stringListFieldValue,
+    FieldValue numListFieldValue,
+    FieldValue objectListFieldValue,
+    FieldValue dynamicListFieldValue,
+    FieldValue boolSetFieldValue,
+    FieldValue enumValueFieldValue,
+    FieldValue nullableEnumValueFieldValue,
+    FieldValue enumListFieldValue,
+    FieldValue nullableEnumListFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -1951,19 +1951,19 @@ abstract class NestedDocumentReference
   void transactionSet(
     Transaction transaction,
     Nested model, {
-    FieldValue? valueFieldValue,
-    FieldValue? simpleFieldValue,
-    FieldValue? valueListFieldValue,
-    FieldValue? boolListFieldValue,
-    FieldValue? stringListFieldValue,
-    FieldValue? numListFieldValue,
-    FieldValue? objectListFieldValue,
-    FieldValue? dynamicListFieldValue,
-    FieldValue? boolSetFieldValue,
-    FieldValue? enumValueFieldValue,
-    FieldValue? nullableEnumValueFieldValue,
-    FieldValue? enumListFieldValue,
-    FieldValue? nullableEnumListFieldValue,
+    FieldValue valueFieldValue,
+    FieldValue simpleFieldValue,
+    FieldValue valueListFieldValue,
+    FieldValue boolListFieldValue,
+    FieldValue stringListFieldValue,
+    FieldValue numListFieldValue,
+    FieldValue objectListFieldValue,
+    FieldValue dynamicListFieldValue,
+    FieldValue boolSetFieldValue,
+    FieldValue enumValueFieldValue,
+    FieldValue nullableEnumValueFieldValue,
+    FieldValue enumListFieldValue,
+    FieldValue nullableEnumListFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -1973,19 +1973,19 @@ abstract class NestedDocumentReference
   void batchSet(
     WriteBatch batch,
     Nested model, {
-    FieldValue? valueFieldValue,
-    FieldValue? simpleFieldValue,
-    FieldValue? valueListFieldValue,
-    FieldValue? boolListFieldValue,
-    FieldValue? stringListFieldValue,
-    FieldValue? numListFieldValue,
-    FieldValue? objectListFieldValue,
-    FieldValue? dynamicListFieldValue,
-    FieldValue? boolSetFieldValue,
-    FieldValue? enumValueFieldValue,
-    FieldValue? nullableEnumValueFieldValue,
-    FieldValue? enumListFieldValue,
-    FieldValue? nullableEnumListFieldValue,
+    FieldValue valueFieldValue,
+    FieldValue simpleFieldValue,
+    FieldValue valueListFieldValue,
+    FieldValue boolListFieldValue,
+    FieldValue stringListFieldValue,
+    FieldValue numListFieldValue,
+    FieldValue objectListFieldValue,
+    FieldValue dynamicListFieldValue,
+    FieldValue boolSetFieldValue,
+    FieldValue enumValueFieldValue,
+    FieldValue nullableEnumValueFieldValue,
+    FieldValue enumListFieldValue,
+    FieldValue nullableEnumListFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -1994,31 +1994,31 @@ abstract class NestedDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     Nested? value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
     int? simple,
-    FieldValue? simpleFieldValue,
+    FieldValue simpleFieldValue,
     List<Nested>? valueList,
-    FieldValue? valueListFieldValue,
+    FieldValue valueListFieldValue,
     List<bool>? boolList,
-    FieldValue? boolListFieldValue,
+    FieldValue boolListFieldValue,
     List<String>? stringList,
-    FieldValue? stringListFieldValue,
+    FieldValue stringListFieldValue,
     List<num>? numList,
-    FieldValue? numListFieldValue,
+    FieldValue numListFieldValue,
     List<Object?>? objectList,
-    FieldValue? objectListFieldValue,
+    FieldValue objectListFieldValue,
     List<dynamic>? dynamicList,
-    FieldValue? dynamicListFieldValue,
+    FieldValue dynamicListFieldValue,
     Set<bool>? boolSet,
-    FieldValue? boolSetFieldValue,
+    FieldValue boolSetFieldValue,
     TestEnum enumValue,
-    FieldValue? enumValueFieldValue,
+    FieldValue enumValueFieldValue,
     TestEnum? nullableEnumValue,
-    FieldValue? nullableEnumValueFieldValue,
+    FieldValue nullableEnumValueFieldValue,
     List<TestEnum> enumList,
-    FieldValue? enumListFieldValue,
+    FieldValue enumListFieldValue,
     List<TestEnum>? nullableEnumList,
-    FieldValue? nullableEnumListFieldValue,
+    FieldValue nullableEnumListFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -2027,31 +2027,31 @@ abstract class NestedDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     Nested? value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
     int? simple,
-    FieldValue? simpleFieldValue,
+    FieldValue simpleFieldValue,
     List<Nested>? valueList,
-    FieldValue? valueListFieldValue,
+    FieldValue valueListFieldValue,
     List<bool>? boolList,
-    FieldValue? boolListFieldValue,
+    FieldValue boolListFieldValue,
     List<String>? stringList,
-    FieldValue? stringListFieldValue,
+    FieldValue stringListFieldValue,
     List<num>? numList,
-    FieldValue? numListFieldValue,
+    FieldValue numListFieldValue,
     List<Object?>? objectList,
-    FieldValue? objectListFieldValue,
+    FieldValue objectListFieldValue,
     List<dynamic>? dynamicList,
-    FieldValue? dynamicListFieldValue,
+    FieldValue dynamicListFieldValue,
     Set<bool>? boolSet,
-    FieldValue? boolSetFieldValue,
+    FieldValue boolSetFieldValue,
     TestEnum enumValue,
-    FieldValue? enumValueFieldValue,
+    FieldValue enumValueFieldValue,
     TestEnum? nullableEnumValue,
-    FieldValue? nullableEnumValueFieldValue,
+    FieldValue nullableEnumValueFieldValue,
     List<TestEnum> enumList,
-    FieldValue? enumListFieldValue,
+    FieldValue enumListFieldValue,
     List<TestEnum>? nullableEnumList,
-    FieldValue? nullableEnumListFieldValue,
+    FieldValue nullableEnumListFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -2060,31 +2060,31 @@ abstract class NestedDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     Nested? value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
     int? simple,
-    FieldValue? simpleFieldValue,
+    FieldValue simpleFieldValue,
     List<Nested>? valueList,
-    FieldValue? valueListFieldValue,
+    FieldValue valueListFieldValue,
     List<bool>? boolList,
-    FieldValue? boolListFieldValue,
+    FieldValue boolListFieldValue,
     List<String>? stringList,
-    FieldValue? stringListFieldValue,
+    FieldValue stringListFieldValue,
     List<num>? numList,
-    FieldValue? numListFieldValue,
+    FieldValue numListFieldValue,
     List<Object?>? objectList,
-    FieldValue? objectListFieldValue,
+    FieldValue objectListFieldValue,
     List<dynamic>? dynamicList,
-    FieldValue? dynamicListFieldValue,
+    FieldValue dynamicListFieldValue,
     Set<bool>? boolSet,
-    FieldValue? boolSetFieldValue,
+    FieldValue boolSetFieldValue,
     TestEnum enumValue,
-    FieldValue? enumValueFieldValue,
+    FieldValue enumValueFieldValue,
     TestEnum? nullableEnumValue,
-    FieldValue? nullableEnumValueFieldValue,
+    FieldValue nullableEnumValueFieldValue,
     List<TestEnum> enumList,
-    FieldValue? enumListFieldValue,
+    FieldValue enumListFieldValue,
     List<TestEnum>? nullableEnumList,
-    FieldValue? nullableEnumListFieldValue,
+    FieldValue nullableEnumListFieldValue,
   });
 }
 
@@ -5818,7 +5818,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   Future<void> set(
     OptionalJson model, {
     SetOptions? setOptions,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -5828,7 +5828,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   void transactionSet(
     Transaction transaction,
     OptionalJson model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -5838,7 +5838,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   void batchSet(
     WriteBatch batch,
     OptionalJson model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -5847,7 +5847,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   /// If no document exists yet, the update will fail.
   Future<void> update({
     int value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -5856,7 +5856,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   void transactionUpdate(
     Transaction transaction, {
     int value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -5865,7 +5865,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   void batchUpdate(
     WriteBatch batch, {
     int value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 }
 
@@ -6723,7 +6723,7 @@ abstract class MixedJsonDocumentReference
   Future<void> set(
     MixedJson model, {
     SetOptions? setOptions,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -6733,7 +6733,7 @@ abstract class MixedJsonDocumentReference
   void transactionSet(
     Transaction transaction,
     MixedJson model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -6743,7 +6743,7 @@ abstract class MixedJsonDocumentReference
   void batchSet(
     WriteBatch batch,
     MixedJson model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -6752,7 +6752,7 @@ abstract class MixedJsonDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     int value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -6761,7 +6761,7 @@ abstract class MixedJsonDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     int value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -6770,7 +6770,7 @@ abstract class MixedJsonDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     int value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 }
 
@@ -7641,8 +7641,8 @@ abstract class RootDocumentReference
   Future<void> set(
     Root model, {
     SetOptions? setOptions,
-    FieldValue? nonNullableFieldValue,
-    FieldValue? nullableFieldValue,
+    FieldValue nonNullableFieldValue,
+    FieldValue nullableFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -7652,8 +7652,8 @@ abstract class RootDocumentReference
   void transactionSet(
     Transaction transaction,
     Root model, {
-    FieldValue? nonNullableFieldValue,
-    FieldValue? nullableFieldValue,
+    FieldValue nonNullableFieldValue,
+    FieldValue nullableFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -7663,8 +7663,8 @@ abstract class RootDocumentReference
   void batchSet(
     WriteBatch batch,
     Root model, {
-    FieldValue? nonNullableFieldValue,
-    FieldValue? nullableFieldValue,
+    FieldValue nonNullableFieldValue,
+    FieldValue nullableFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -7673,9 +7673,9 @@ abstract class RootDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     String nonNullable,
-    FieldValue? nonNullableFieldValue,
+    FieldValue nonNullableFieldValue,
     int? nullable,
-    FieldValue? nullableFieldValue,
+    FieldValue nullableFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -7684,9 +7684,9 @@ abstract class RootDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     String nonNullable,
-    FieldValue? nonNullableFieldValue,
+    FieldValue nonNullableFieldValue,
     int? nullable,
-    FieldValue? nullableFieldValue,
+    FieldValue nullableFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -7695,9 +7695,9 @@ abstract class RootDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     String nonNullable,
-    FieldValue? nonNullableFieldValue,
+    FieldValue nonNullableFieldValue,
     int? nullable,
-    FieldValue? nullableFieldValue,
+    FieldValue nullableFieldValue,
   });
 }
 
@@ -8757,8 +8757,8 @@ abstract class SubDocumentReference
   Future<void> set(
     Sub model, {
     SetOptions? setOptions,
-    FieldValue? nonNullableFieldValue,
-    FieldValue? nullableFieldValue,
+    FieldValue nonNullableFieldValue,
+    FieldValue nullableFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -8768,8 +8768,8 @@ abstract class SubDocumentReference
   void transactionSet(
     Transaction transaction,
     Sub model, {
-    FieldValue? nonNullableFieldValue,
-    FieldValue? nullableFieldValue,
+    FieldValue nonNullableFieldValue,
+    FieldValue nullableFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -8779,8 +8779,8 @@ abstract class SubDocumentReference
   void batchSet(
     WriteBatch batch,
     Sub model, {
-    FieldValue? nonNullableFieldValue,
-    FieldValue? nullableFieldValue,
+    FieldValue nonNullableFieldValue,
+    FieldValue nullableFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -8789,9 +8789,9 @@ abstract class SubDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     String nonNullable,
-    FieldValue? nonNullableFieldValue,
+    FieldValue nonNullableFieldValue,
     int? nullable,
-    FieldValue? nullableFieldValue,
+    FieldValue nullableFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -8800,9 +8800,9 @@ abstract class SubDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     String nonNullable,
-    FieldValue? nonNullableFieldValue,
+    FieldValue nonNullableFieldValue,
     int? nullable,
-    FieldValue? nullableFieldValue,
+    FieldValue nullableFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -8811,9 +8811,9 @@ abstract class SubDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     String nonNullable,
-    FieldValue? nonNullableFieldValue,
+    FieldValue nonNullableFieldValue,
     int? nullable,
-    FieldValue? nullableFieldValue,
+    FieldValue nullableFieldValue,
   });
 }
 
@@ -9864,7 +9864,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   Future<void> set(
     AsCamelCase model, {
     SetOptions? setOptions,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -9874,7 +9874,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   void transactionSet(
     Transaction transaction,
     AsCamelCase model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -9884,7 +9884,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   void batchSet(
     WriteBatch batch,
     AsCamelCase model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -9893,7 +9893,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   /// If no document exists yet, the update will fail.
   Future<void> update({
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -9902,7 +9902,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   void transactionUpdate(
     Transaction transaction, {
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -9911,7 +9911,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   void batchUpdate(
     WriteBatch batch, {
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 }
 
@@ -10791,7 +10791,7 @@ abstract class CustomSubNameDocumentReference
   Future<void> set(
     CustomSubName model, {
     SetOptions? setOptions,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -10801,7 +10801,7 @@ abstract class CustomSubNameDocumentReference
   void transactionSet(
     Transaction transaction,
     CustomSubName model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -10811,7 +10811,7 @@ abstract class CustomSubNameDocumentReference
   void batchSet(
     WriteBatch batch,
     CustomSubName model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -10820,7 +10820,7 @@ abstract class CustomSubNameDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -10829,7 +10829,7 @@ abstract class CustomSubNameDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -10838,7 +10838,7 @@ abstract class CustomSubNameDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 }
 
@@ -11721,7 +11721,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   Future<void> set(
     CustomClassPrefix model, {
     SetOptions? setOptions,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -11731,7 +11731,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   void transactionSet(
     Transaction transaction,
     CustomClassPrefix model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -11741,7 +11741,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   void batchSet(
     WriteBatch batch,
     CustomClassPrefix model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -11750,7 +11750,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -11759,7 +11759,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -11768,7 +11768,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 }
 
@@ -12650,7 +12650,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   Future<void> set(
     ExplicitPath model, {
     SetOptions? setOptions,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -12660,7 +12660,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   void transactionSet(
     Transaction transaction,
     ExplicitPath model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -12670,7 +12670,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   void batchSet(
     WriteBatch batch,
     ExplicitPath model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -12679,7 +12679,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   /// If no document exists yet, the update will fail.
   Future<void> update({
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -12688,7 +12688,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   void transactionUpdate(
     Transaction transaction, {
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -12697,7 +12697,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   void batchUpdate(
     WriteBatch batch, {
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 }
 
@@ -13578,7 +13578,7 @@ abstract class ExplicitSubPathDocumentReference
   Future<void> set(
     ExplicitSubPath model, {
     SetOptions? setOptions,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the transaction API.
@@ -13588,7 +13588,7 @@ abstract class ExplicitSubPathDocumentReference
   void transactionSet(
     Transaction transaction,
     ExplicitSubPath model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Writes to the document using the batch API.
@@ -13598,7 +13598,7 @@ abstract class ExplicitSubPathDocumentReference
   void batchSet(
     WriteBatch batch,
     ExplicitSubPath model, {
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates data on the document. Data will be merged with any existing
@@ -13607,7 +13607,7 @@ abstract class ExplicitSubPathDocumentReference
   /// If no document exists yet, the update will fail.
   Future<void> update({
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -13616,7 +13616,7 @@ abstract class ExplicitSubPathDocumentReference
   void transactionUpdate(
     Transaction transaction, {
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 
   /// Updates fields in the current document using the batch API.
@@ -13625,7 +13625,7 @@ abstract class ExplicitSubPathDocumentReference
   void batchUpdate(
     WriteBatch batch, {
     num value,
-    FieldValue? valueFieldValue,
+    FieldValue valueFieldValue,
   });
 }
 

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
@@ -165,7 +165,7 @@ abstract class IgnoredGetterDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? value = _sentinel,
+    int value,
     FieldValue? valueFieldValue,
   });
 
@@ -174,7 +174,7 @@ abstract class IgnoredGetterDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? value = _sentinel,
+    int value,
     FieldValue? valueFieldValue,
   });
 
@@ -183,7 +183,7 @@ abstract class IgnoredGetterDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? value = _sentinel,
+    int value,
     FieldValue? valueFieldValue,
   });
 }
@@ -1071,7 +1071,7 @@ abstract class ModelDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? value = _sentinel,
+    String value,
     FieldValue? valueFieldValue,
   });
 
@@ -1080,7 +1080,7 @@ abstract class ModelDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? value = _sentinel,
+    String value,
     FieldValue? valueFieldValue,
   });
 
@@ -1089,7 +1089,7 @@ abstract class ModelDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? value = _sentinel,
+    String value,
     FieldValue? valueFieldValue,
   });
 }
@@ -1993,31 +1993,31 @@ abstract class NestedDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? value = _sentinel,
+    Nested? value,
     FieldValue? valueFieldValue,
-    Object? simple = _sentinel,
+    int? simple,
     FieldValue? simpleFieldValue,
-    Object? valueList = _sentinel,
+    List<Nested>? valueList,
     FieldValue? valueListFieldValue,
-    Object? boolList = _sentinel,
+    List<bool>? boolList,
     FieldValue? boolListFieldValue,
-    Object? stringList = _sentinel,
+    List<String>? stringList,
     FieldValue? stringListFieldValue,
-    Object? numList = _sentinel,
+    List<num>? numList,
     FieldValue? numListFieldValue,
-    Object? objectList = _sentinel,
+    List<Object?>? objectList,
     FieldValue? objectListFieldValue,
-    Object? dynamicList = _sentinel,
+    List<dynamic>? dynamicList,
     FieldValue? dynamicListFieldValue,
-    Object? boolSet = _sentinel,
+    Set<bool>? boolSet,
     FieldValue? boolSetFieldValue,
-    Object? enumValue = _sentinel,
+    TestEnum enumValue,
     FieldValue? enumValueFieldValue,
-    Object? nullableEnumValue = _sentinel,
+    TestEnum? nullableEnumValue,
     FieldValue? nullableEnumValueFieldValue,
-    Object? enumList = _sentinel,
+    List<TestEnum> enumList,
     FieldValue? enumListFieldValue,
-    Object? nullableEnumList = _sentinel,
+    List<TestEnum>? nullableEnumList,
     FieldValue? nullableEnumListFieldValue,
   });
 
@@ -2026,31 +2026,31 @@ abstract class NestedDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? value = _sentinel,
+    Nested? value,
     FieldValue? valueFieldValue,
-    Object? simple = _sentinel,
+    int? simple,
     FieldValue? simpleFieldValue,
-    Object? valueList = _sentinel,
+    List<Nested>? valueList,
     FieldValue? valueListFieldValue,
-    Object? boolList = _sentinel,
+    List<bool>? boolList,
     FieldValue? boolListFieldValue,
-    Object? stringList = _sentinel,
+    List<String>? stringList,
     FieldValue? stringListFieldValue,
-    Object? numList = _sentinel,
+    List<num>? numList,
     FieldValue? numListFieldValue,
-    Object? objectList = _sentinel,
+    List<Object?>? objectList,
     FieldValue? objectListFieldValue,
-    Object? dynamicList = _sentinel,
+    List<dynamic>? dynamicList,
     FieldValue? dynamicListFieldValue,
-    Object? boolSet = _sentinel,
+    Set<bool>? boolSet,
     FieldValue? boolSetFieldValue,
-    Object? enumValue = _sentinel,
+    TestEnum enumValue,
     FieldValue? enumValueFieldValue,
-    Object? nullableEnumValue = _sentinel,
+    TestEnum? nullableEnumValue,
     FieldValue? nullableEnumValueFieldValue,
-    Object? enumList = _sentinel,
+    List<TestEnum> enumList,
     FieldValue? enumListFieldValue,
-    Object? nullableEnumList = _sentinel,
+    List<TestEnum>? nullableEnumList,
     FieldValue? nullableEnumListFieldValue,
   });
 
@@ -2059,31 +2059,31 @@ abstract class NestedDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? value = _sentinel,
+    Nested? value,
     FieldValue? valueFieldValue,
-    Object? simple = _sentinel,
+    int? simple,
     FieldValue? simpleFieldValue,
-    Object? valueList = _sentinel,
+    List<Nested>? valueList,
     FieldValue? valueListFieldValue,
-    Object? boolList = _sentinel,
+    List<bool>? boolList,
     FieldValue? boolListFieldValue,
-    Object? stringList = _sentinel,
+    List<String>? stringList,
     FieldValue? stringListFieldValue,
-    Object? numList = _sentinel,
+    List<num>? numList,
     FieldValue? numListFieldValue,
-    Object? objectList = _sentinel,
+    List<Object?>? objectList,
     FieldValue? objectListFieldValue,
-    Object? dynamicList = _sentinel,
+    List<dynamic>? dynamicList,
     FieldValue? dynamicListFieldValue,
-    Object? boolSet = _sentinel,
+    Set<bool>? boolSet,
     FieldValue? boolSetFieldValue,
-    Object? enumValue = _sentinel,
+    TestEnum enumValue,
     FieldValue? enumValueFieldValue,
-    Object? nullableEnumValue = _sentinel,
+    TestEnum? nullableEnumValue,
     FieldValue? nullableEnumValueFieldValue,
-    Object? enumList = _sentinel,
+    List<TestEnum> enumList,
     FieldValue? enumListFieldValue,
-    Object? nullableEnumList = _sentinel,
+    List<TestEnum>? nullableEnumList,
     FieldValue? nullableEnumListFieldValue,
   });
 }
@@ -5846,7 +5846,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? value = _sentinel,
+    int value,
     FieldValue? valueFieldValue,
   });
 
@@ -5855,7 +5855,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? value = _sentinel,
+    int value,
     FieldValue? valueFieldValue,
   });
 
@@ -5864,7 +5864,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? value = _sentinel,
+    int value,
     FieldValue? valueFieldValue,
   });
 }
@@ -6751,7 +6751,7 @@ abstract class MixedJsonDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? value = _sentinel,
+    int value,
     FieldValue? valueFieldValue,
   });
 
@@ -6760,7 +6760,7 @@ abstract class MixedJsonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? value = _sentinel,
+    int value,
     FieldValue? valueFieldValue,
   });
 
@@ -6769,7 +6769,7 @@ abstract class MixedJsonDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? value = _sentinel,
+    int value,
     FieldValue? valueFieldValue,
   });
 }
@@ -7672,9 +7672,9 @@ abstract class RootDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? nonNullable = _sentinel,
+    String nonNullable,
     FieldValue? nonNullableFieldValue,
-    Object? nullable = _sentinel,
+    int? nullable,
     FieldValue? nullableFieldValue,
   });
 
@@ -7683,9 +7683,9 @@ abstract class RootDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? nonNullable = _sentinel,
+    String nonNullable,
     FieldValue? nonNullableFieldValue,
-    Object? nullable = _sentinel,
+    int? nullable,
     FieldValue? nullableFieldValue,
   });
 
@@ -7694,9 +7694,9 @@ abstract class RootDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? nonNullable = _sentinel,
+    String nonNullable,
     FieldValue? nonNullableFieldValue,
-    Object? nullable = _sentinel,
+    int? nullable,
     FieldValue? nullableFieldValue,
   });
 }
@@ -8788,9 +8788,9 @@ abstract class SubDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? nonNullable = _sentinel,
+    String nonNullable,
     FieldValue? nonNullableFieldValue,
-    Object? nullable = _sentinel,
+    int? nullable,
     FieldValue? nullableFieldValue,
   });
 
@@ -8799,9 +8799,9 @@ abstract class SubDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? nonNullable = _sentinel,
+    String nonNullable,
     FieldValue? nonNullableFieldValue,
-    Object? nullable = _sentinel,
+    int? nullable,
     FieldValue? nullableFieldValue,
   });
 
@@ -8810,9 +8810,9 @@ abstract class SubDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? nonNullable = _sentinel,
+    String nonNullable,
     FieldValue? nonNullableFieldValue,
-    Object? nullable = _sentinel,
+    int? nullable,
     FieldValue? nullableFieldValue,
   });
 }
@@ -9892,7 +9892,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 
@@ -9901,7 +9901,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 
@@ -9910,7 +9910,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 }
@@ -10819,7 +10819,7 @@ abstract class CustomSubNameDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 
@@ -10828,7 +10828,7 @@ abstract class CustomSubNameDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 
@@ -10837,7 +10837,7 @@ abstract class CustomSubNameDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 }
@@ -11749,7 +11749,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 
@@ -11758,7 +11758,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 
@@ -11767,7 +11767,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 }
@@ -12678,7 +12678,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 
@@ -12687,7 +12687,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 
@@ -12696,7 +12696,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 }
@@ -13606,7 +13606,7 @@ abstract class ExplicitSubPathDocumentReference
   ///
   /// If no document exists yet, the update will fail.
   Future<void> update({
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 
@@ -13615,7 +13615,7 @@ abstract class ExplicitSubPathDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void transactionUpdate(
     Transaction transaction, {
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 
@@ -13624,7 +13624,7 @@ abstract class ExplicitSubPathDocumentReference
   /// The update will fail if applied to a document that does not exist.
   void batchUpdate(
     WriteBatch batch, {
-    Object? value = _sentinel,
+    num value,
     FieldValue? valueFieldValue,
   });
 }

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
@@ -139,7 +139,7 @@ abstract class IgnoredGetterDocumentReference
   /// [model] during serialization.
   Future<void> set(
     IgnoredGetter model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -153,6 +153,7 @@ abstract class IgnoredGetterDocumentReference
   void transactionSet(
     Transaction transaction,
     IgnoredGetter model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -166,6 +167,7 @@ abstract class IgnoredGetterDocumentReference
   void batchSet(
     WriteBatch batch,
     IgnoredGetter model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -228,7 +230,7 @@ class _$IgnoredGetterDocumentReference extends FirestoreDocumentReference<
 
   Future<void> set(
     IgnoredGetter model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) async {
     final json = {
@@ -237,12 +239,13 @@ class _$IgnoredGetterDocumentReference extends FirestoreDocumentReference<
         _$IgnoredGetterFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     IgnoredGetter model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -251,12 +254,13 @@ class _$IgnoredGetterDocumentReference extends FirestoreDocumentReference<
         _$IgnoredGetterFieldMap['value']!: valueFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     IgnoredGetter model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -265,7 +269,7 @@ class _$IgnoredGetterDocumentReference extends FirestoreDocumentReference<
         _$IgnoredGetterFieldMap['value']!: valueFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -1054,7 +1058,7 @@ abstract class ModelDocumentReference
   /// [model] during serialization.
   Future<void> set(
     Model model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -1068,6 +1072,7 @@ abstract class ModelDocumentReference
   void transactionSet(
     Transaction transaction,
     Model model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -1081,6 +1086,7 @@ abstract class ModelDocumentReference
   void batchSet(
     WriteBatch batch,
     Model model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -1142,7 +1148,7 @@ class _$ModelDocumentReference
 
   Future<void> set(
     Model model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) async {
     final json = {
@@ -1150,12 +1156,13 @@ class _$ModelDocumentReference
       if (valueFieldValue != null) _$ModelFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     Model model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -1163,12 +1170,13 @@ class _$ModelDocumentReference
       if (valueFieldValue != null) _$ModelFieldMap['value']!: valueFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     Model model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -1176,7 +1184,7 @@ class _$ModelDocumentReference
       if (valueFieldValue != null) _$ModelFieldMap['value']!: valueFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -1949,7 +1957,7 @@ abstract class NestedDocumentReference
   /// [model] during serialization.
   Future<void> set(
     Nested model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue valueFieldValue,
     FieldValue simpleFieldValue,
     FieldValue valueListFieldValue,
@@ -1975,6 +1983,7 @@ abstract class NestedDocumentReference
   void transactionSet(
     Transaction transaction,
     Nested model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
     FieldValue simpleFieldValue,
     FieldValue valueListFieldValue,
@@ -2000,6 +2009,7 @@ abstract class NestedDocumentReference
   void batchSet(
     WriteBatch batch,
     Nested model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
     FieldValue simpleFieldValue,
     FieldValue valueListFieldValue,
@@ -2145,7 +2155,7 @@ class _$NestedDocumentReference
 
   Future<void> set(
     Nested model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? valueFieldValue,
     FieldValue? simpleFieldValue,
     FieldValue? valueListFieldValue,
@@ -2189,12 +2199,13 @@ class _$NestedDocumentReference
         _$NestedFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     Nested model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
     FieldValue? simpleFieldValue,
     FieldValue? valueListFieldValue,
@@ -2238,12 +2249,13 @@ class _$NestedDocumentReference
         _$NestedFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     Nested model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
     FieldValue? simpleFieldValue,
     FieldValue? valueListFieldValue,
@@ -2287,7 +2299,7 @@ class _$NestedDocumentReference
         _$NestedFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -5847,7 +5859,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   /// [model] during serialization.
   Future<void> set(
     OptionalJson model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -5861,6 +5873,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   void transactionSet(
     Transaction transaction,
     OptionalJson model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -5874,6 +5887,7 @@ abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
   void batchSet(
     WriteBatch batch,
     OptionalJson model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -5935,7 +5949,7 @@ class _$OptionalJsonDocumentReference extends FirestoreDocumentReference<
 
   Future<void> set(
     OptionalJson model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) async {
     final json = {
@@ -5944,12 +5958,13 @@ class _$OptionalJsonDocumentReference extends FirestoreDocumentReference<
         _$OptionalJsonFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     OptionalJson model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -5958,12 +5973,13 @@ class _$OptionalJsonDocumentReference extends FirestoreDocumentReference<
         _$OptionalJsonFieldMap['value']!: valueFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     OptionalJson model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -5972,7 +5988,7 @@ class _$OptionalJsonDocumentReference extends FirestoreDocumentReference<
         _$OptionalJsonFieldMap['value']!: valueFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -6761,7 +6777,7 @@ abstract class MixedJsonDocumentReference
   /// [model] during serialization.
   Future<void> set(
     MixedJson model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -6775,6 +6791,7 @@ abstract class MixedJsonDocumentReference
   void transactionSet(
     Transaction transaction,
     MixedJson model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -6788,6 +6805,7 @@ abstract class MixedJsonDocumentReference
   void batchSet(
     WriteBatch batch,
     MixedJson model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -6849,7 +6867,7 @@ class _$MixedJsonDocumentReference
 
   Future<void> set(
     MixedJson model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) async {
     final json = {
@@ -6858,12 +6876,13 @@ class _$MixedJsonDocumentReference
         _$MixedJsonFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     MixedJson model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -6872,12 +6891,13 @@ class _$MixedJsonDocumentReference
         _$MixedJsonFieldMap['value']!: valueFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     MixedJson model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -6886,7 +6906,7 @@ class _$MixedJsonDocumentReference
         _$MixedJsonFieldMap['value']!: valueFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -7688,7 +7708,7 @@ abstract class RootDocumentReference
   /// [model] during serialization.
   Future<void> set(
     Root model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue nonNullableFieldValue,
     FieldValue nullableFieldValue,
   });
@@ -7703,6 +7723,7 @@ abstract class RootDocumentReference
   void transactionSet(
     Transaction transaction,
     Root model, {
+    SetOptions? options,
     FieldValue nonNullableFieldValue,
     FieldValue nullableFieldValue,
   });
@@ -7717,6 +7738,7 @@ abstract class RootDocumentReference
   void batchSet(
     WriteBatch batch,
     Root model, {
+    SetOptions? options,
     FieldValue nonNullableFieldValue,
     FieldValue nullableFieldValue,
   });
@@ -7804,7 +7826,7 @@ class _$RootDocumentReference
 
   Future<void> set(
     Root model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? nonNullableFieldValue,
     FieldValue? nullableFieldValue,
   }) async {
@@ -7816,12 +7838,13 @@ class _$RootDocumentReference
         _$RootFieldMap['nullable']!: nullableFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     Root model, {
+    SetOptions? options,
     FieldValue? nonNullableFieldValue,
     FieldValue? nullableFieldValue,
   }) {
@@ -7833,12 +7856,13 @@ class _$RootDocumentReference
         _$RootFieldMap['nullable']!: nullableFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     Root model, {
+    SetOptions? options,
     FieldValue? nonNullableFieldValue,
     FieldValue? nullableFieldValue,
   }) {
@@ -7850,7 +7874,7 @@ class _$RootDocumentReference
         _$RootFieldMap['nullable']!: nullableFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -8813,7 +8837,7 @@ abstract class SubDocumentReference
   /// [model] during serialization.
   Future<void> set(
     Sub model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue nonNullableFieldValue,
     FieldValue nullableFieldValue,
   });
@@ -8828,6 +8852,7 @@ abstract class SubDocumentReference
   void transactionSet(
     Transaction transaction,
     Sub model, {
+    SetOptions? options,
     FieldValue nonNullableFieldValue,
     FieldValue nullableFieldValue,
   });
@@ -8842,6 +8867,7 @@ abstract class SubDocumentReference
   void batchSet(
     WriteBatch batch,
     Sub model, {
+    SetOptions? options,
     FieldValue nonNullableFieldValue,
     FieldValue nullableFieldValue,
   });
@@ -8915,7 +8941,7 @@ class _$SubDocumentReference
 
   Future<void> set(
     Sub model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? nonNullableFieldValue,
     FieldValue? nullableFieldValue,
   }) async {
@@ -8927,12 +8953,13 @@ class _$SubDocumentReference
         _$SubFieldMap['nullable']!: nullableFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     Sub model, {
+    SetOptions? options,
     FieldValue? nonNullableFieldValue,
     FieldValue? nullableFieldValue,
   }) {
@@ -8944,12 +8971,13 @@ class _$SubDocumentReference
         _$SubFieldMap['nullable']!: nullableFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     Sub model, {
+    SetOptions? options,
     FieldValue? nonNullableFieldValue,
     FieldValue? nullableFieldValue,
   }) {
@@ -8961,7 +8989,7 @@ class _$SubDocumentReference
         _$SubFieldMap['nullable']!: nullableFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -9929,7 +9957,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   /// [model] during serialization.
   Future<void> set(
     AsCamelCase model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -9943,6 +9971,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   void transactionSet(
     Transaction transaction,
     AsCamelCase model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -9956,6 +9985,7 @@ abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
   void batchSet(
     WriteBatch batch,
     AsCamelCase model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -10022,7 +10052,7 @@ class _$AsCamelCaseDocumentReference
 
   Future<void> set(
     AsCamelCase model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) async {
     final json = {
@@ -10031,12 +10061,13 @@ class _$AsCamelCaseDocumentReference
         _$AsCamelCaseFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     AsCamelCase model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -10045,12 +10076,13 @@ class _$AsCamelCaseDocumentReference
         _$AsCamelCaseFieldMap['value']!: valueFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     AsCamelCase model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -10059,7 +10091,7 @@ class _$AsCamelCaseDocumentReference
         _$AsCamelCaseFieldMap['value']!: valueFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -10865,7 +10897,7 @@ abstract class CustomSubNameDocumentReference
   /// [model] during serialization.
   Future<void> set(
     CustomSubName model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -10879,6 +10911,7 @@ abstract class CustomSubNameDocumentReference
   void transactionSet(
     Transaction transaction,
     CustomSubName model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -10892,6 +10925,7 @@ abstract class CustomSubNameDocumentReference
   void batchSet(
     WriteBatch batch,
     CustomSubName model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -10959,7 +10993,7 @@ class _$CustomSubNameDocumentReference extends FirestoreDocumentReference<
 
   Future<void> set(
     CustomSubName model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) async {
     final json = {
@@ -10968,12 +11002,13 @@ class _$CustomSubNameDocumentReference extends FirestoreDocumentReference<
         _$CustomSubNameFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     CustomSubName model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -10982,12 +11017,13 @@ class _$CustomSubNameDocumentReference extends FirestoreDocumentReference<
         _$CustomSubNameFieldMap['value']!: valueFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     CustomSubName model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -10996,7 +11032,7 @@ class _$CustomSubNameDocumentReference extends FirestoreDocumentReference<
         _$CustomSubNameFieldMap['value']!: valueFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -11804,7 +11840,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   /// [model] during serialization.
   Future<void> set(
     CustomClassPrefix model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -11818,6 +11854,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   void transactionSet(
     Transaction transaction,
     CustomClassPrefix model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -11831,6 +11868,7 @@ abstract class ThisIsACustomPrefixDocumentReference
   void batchSet(
     WriteBatch batch,
     CustomClassPrefix model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -11900,7 +11938,7 @@ class _$ThisIsACustomPrefixDocumentReference extends FirestoreDocumentReference<
 
   Future<void> set(
     CustomClassPrefix model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) async {
     final json = {
@@ -11909,12 +11947,13 @@ class _$ThisIsACustomPrefixDocumentReference extends FirestoreDocumentReference<
         _$CustomClassPrefixFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     CustomClassPrefix model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -11923,12 +11962,13 @@ class _$ThisIsACustomPrefixDocumentReference extends FirestoreDocumentReference<
         _$CustomClassPrefixFieldMap['value']!: valueFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     CustomClassPrefix model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -11937,7 +11977,7 @@ class _$ThisIsACustomPrefixDocumentReference extends FirestoreDocumentReference<
         _$CustomClassPrefixFieldMap['value']!: valueFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -12742,7 +12782,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   /// [model] during serialization.
   Future<void> set(
     ExplicitPath model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -12756,6 +12796,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   void transactionSet(
     Transaction transaction,
     ExplicitPath model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -12769,6 +12810,7 @@ abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
   void batchSet(
     WriteBatch batch,
     ExplicitPath model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -12835,7 +12877,7 @@ class _$ExplicitPathDocumentReference extends FirestoreDocumentReference<
 
   Future<void> set(
     ExplicitPath model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) async {
     final json = {
@@ -12844,12 +12886,13 @@ class _$ExplicitPathDocumentReference extends FirestoreDocumentReference<
         _$ExplicitPathFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     ExplicitPath model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -12858,12 +12901,13 @@ class _$ExplicitPathDocumentReference extends FirestoreDocumentReference<
         _$ExplicitPathFieldMap['value']!: valueFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     ExplicitPath model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -12872,7 +12916,7 @@ class _$ExplicitPathDocumentReference extends FirestoreDocumentReference<
         _$ExplicitPathFieldMap['value']!: valueFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({
@@ -13679,7 +13723,7 @@ abstract class ExplicitSubPathDocumentReference
   /// [model] during serialization.
   Future<void> set(
     ExplicitSubPath model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -13693,6 +13737,7 @@ abstract class ExplicitSubPathDocumentReference
   void transactionSet(
     Transaction transaction,
     ExplicitSubPath model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -13706,6 +13751,7 @@ abstract class ExplicitSubPathDocumentReference
   void batchSet(
     WriteBatch batch,
     ExplicitSubPath model, {
+    SetOptions? options,
     FieldValue valueFieldValue,
   });
 
@@ -13773,7 +13819,7 @@ class _$ExplicitSubPathDocumentReference extends FirestoreDocumentReference<
 
   Future<void> set(
     ExplicitSubPath model, {
-    SetOptions? setOptions,
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) async {
     final json = {
@@ -13782,12 +13828,13 @@ class _$ExplicitSubPathDocumentReference extends FirestoreDocumentReference<
         _$ExplicitSubPathFieldMap['value']!: valueFieldValue,
     };
 
-    return (reference as DocumentReference).set(json);
+    return (reference as DocumentReference).set(json, options);
   }
 
   void transactionSet(
     Transaction transaction,
     ExplicitSubPath model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -13796,12 +13843,13 @@ class _$ExplicitSubPathDocumentReference extends FirestoreDocumentReference<
         _$ExplicitSubPathFieldMap['value']!: valueFieldValue,
     };
 
-    transaction.set(reference, json);
+    transaction.set(reference, json, options);
   }
 
   void batchSet(
     WriteBatch batch,
     ExplicitSubPath model, {
+    SetOptions? options,
     FieldValue? valueFieldValue,
   }) {
     final json = {
@@ -13810,7 +13858,7 @@ class _$ExplicitSubPathDocumentReference extends FirestoreDocumentReference<
         _$ExplicitSubPathFieldMap['value']!: valueFieldValue,
     };
 
-    batch.set(reference, json);
+    batch.set(reference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/pubspec.yaml
+++ b/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/pubspec.yaml
@@ -15,11 +15,16 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.2
-  cloud_firestore_odm_generator: ^1.0.0-dev.86
+  cloud_firestore_odm_generator:
+    path: ../
   flutter_test:
     sdk: flutter
   freezed: ^2.3.2
   json_serializable: '>=6.6.1 <7.0.0'
+
+dependency_overrides:
+  cloud_firestore_odm:
+    path: ../../cloud_firestore_odm
 
 flutter:
   uses-material-design: false

--- a/packages/cloud_firestore_odm_generator/lib/src/names.dart
+++ b/packages/cloud_firestore_odm_generator/lib/src/names.dart
@@ -11,7 +11,7 @@ mixin Names {
   DartType get type;
 
   late final String classPrefix = collectionPrefix ??
-      type.getDisplayString(withNullability: false).replaceFirstMapped(
+      type.getDisplayString().replaceFirstMapped(
             RegExp('[a-zA-Z]'),
             (match) => match.group(0)!.toUpperCase(),
           );

--- a/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
+++ b/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
@@ -137,15 +137,18 @@ class _\$${data.documentReferenceName}
     final type = data.type.getDisplayString();
     final parameters = _parameters(data, includeFields: false);
 
+    const fieldValueDoc = '''
+/// Any [FieldValue]s provided will replace the corresponding fields in the
+/// [model] during serialization.''';
+
     return '''
 /// Sets data on the document, overwriting any existing data. If the document
 /// does not yet exist, it will be created.
 ///
 /// If [SetOptions] are provided, the data can be merged into an existing
 /// document instead of overwriting.
-/// 
-/// Any [FieldValue]s provided will replace the corresponding fields in the
-/// model during serialization.
+///
+$fieldValueDoc
 Future<void> set(
   $type model, {
   SetOptions? setOptions,
@@ -156,9 +159,8 @@ Future<void> set(
 ///
 /// If the document does not exist yet, it will be created. If you pass
 /// [SetOptions], the provided data can be merged into the existing document.
-/// 
-/// Any [FieldValue]s provided will replace the corresponding fields in the
-/// model during serialization.
+///
+$fieldValueDoc
 void transactionSet(
   Transaction transaction,
   $type model, {
@@ -169,9 +171,8 @@ void transactionSet(
 ///
 /// If the document does not exist yet, it will be created. If you pass
 /// [SetOptions], the provided data can be merged into the existing document.
-/// 
-/// Any [FieldValue]s provided will replace the corresponding fields in the
-/// model during serialization.
+///
+$fieldValueDoc
 void batchSet(
   WriteBatch batch,
   $type model, {

--- a/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
+++ b/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
@@ -76,6 +76,7 @@ class _\$${data.documentReferenceName}
     bool includeFields = true,
     bool useSentinel = false,
     bool includeFieldValues = true,
+    bool fieldValuesNullable = false,
   }) {
     final parameters = <String>[];
 
@@ -89,7 +90,8 @@ class _\$${data.documentReferenceName}
         parameters.add('$type ${field.name}$defaultValue,');
       }
       if (includeFieldValues) {
-        parameters.add('FieldValue? ${field.name}FieldValue,');
+        final suffix = fieldValuesNullable ? '?' : '';
+        parameters.add('FieldValue$suffix ${field.name}FieldValue,');
       }
     }
 
@@ -173,7 +175,11 @@ void batchSet(
     if (data.updatableFields.isEmpty) return '';
 
     final type = data.type.getDisplayString();
-    final parameters = _parameters(data, includeFields: false);
+    final parameters = _parameters(
+      data,
+      includeFields: false,
+      fieldValuesNullable: true,
+    );
     final fieldValuesJson = _json(data, includeFields: false);
     final json = '''
 {
@@ -241,7 +247,11 @@ void batchUpdate(WriteBatch batch, {$parameters});
   String _update(CollectionData data) {
     if (data.updatableFields.isEmpty) return '';
 
-    final parameters = _parameters(data, useSentinel: true);
+    final parameters = _parameters(
+      data,
+      useSentinel: true,
+      fieldValuesNullable: true,
+    );
     final json = _json(data);
     final asserts = _asserts(data);
 

--- a/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
+++ b/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
@@ -207,7 +207,11 @@ Future<void> set(
 }) async {
   final json = $json;
 
-  return (reference as DocumentReference).set(json, options);
+  final castedReference = reference.withConverter<Map<String, dynamic>>(
+    fromFirestore: (snapshot, options) => throw UnimplementedError(),
+    toFirestore: (value, options) => value,
+  );
+  return castedReference.set(json, options);
 }
 
 void transactionSet(

--- a/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
+++ b/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
@@ -151,7 +151,7 @@ class _\$${data.documentReferenceName}
 $fieldValueDoc
 Future<void> set(
   $type model, {
-  SetOptions? setOptions,
+  SetOptions? options,
   $parameters
 });
 
@@ -164,6 +164,7 @@ $fieldValueDoc
 void transactionSet(
   Transaction transaction,
   $type model, {
+  SetOptions? options,
   $parameters
 });
 
@@ -176,6 +177,7 @@ $fieldValueDoc
 void batchSet(
   WriteBatch batch,
   $type model, {
+  SetOptions? options,
   $parameters
 });
 ''';
@@ -200,32 +202,34 @@ void batchSet(
     return '''
 Future<void> set(
   $type model, {
-  SetOptions? setOptions,
+  SetOptions? options,
   $parameters
 }) async {
   final json = $json;
 
-  return (reference as DocumentReference).set(json);
+  return (reference as DocumentReference).set(json, options);
 }
 
 void transactionSet(
   Transaction transaction,
   $type model, {
+  SetOptions? options,
   $parameters
 }) {
   final json = $json;
 
-  transaction.set(reference, json);
+  transaction.set(reference, json, options);
 }
 
 void batchSet(
   WriteBatch batch,
   $type model, {
+  SetOptions? options,
   $parameters
 }) {
   final json = $json;
 
-  batch.set(reference, json);
+  batch.set(reference, json, options);
 }
 ''';
   }

--- a/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
+++ b/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
@@ -74,15 +74,26 @@ class _\$${data.documentReferenceName}
   String _parameters(
     CollectionData data, {
     bool includeFields = true,
+    bool useSentinel = false,
     bool includeFieldValues = true,
   }) {
-    return [
-      for (final field in data.updatableFields)
-        if (field.updatable) ...[
-          if (includeFields) 'Object? ${field.name} = _sentinel,',
-          if (includeFieldValues) 'FieldValue? ${field.name}FieldValue,',
-        ],
-    ].join('\n');
+    final parameters = <String>[];
+
+    for (final field in data.updatableFields) {
+      if (!field.updatable) continue;
+
+      final fieldType = field.type.getDisplayString();
+      if (includeFields) {
+        final type = useSentinel ? 'Object?' : fieldType;
+        final defaultValue = useSentinel ? ' = _sentinel' : '';
+        parameters.add('$type ${field.name}$defaultValue,');
+      }
+      if (includeFieldValues) {
+        parameters.add('FieldValue? ${field.name}FieldValue,');
+      }
+    }
+
+    return parameters.join('\n');
   }
 
   // TODO support nested objects
@@ -230,7 +241,7 @@ void batchUpdate(WriteBatch batch, {$parameters});
   String _update(CollectionData data) {
     if (data.updatableFields.isEmpty) return '';
 
-    final parameters = _parameters(data);
+    final parameters = _parameters(data, useSentinel: true);
     final json = _json(data);
     final asserts = _asserts(data);
 

--- a/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
+++ b/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
@@ -79,9 +79,8 @@ class _\$${data.documentReferenceName}
     return [
       for (final field in data.updatableFields)
         if (field.updatable) ...[
-          if (includeFields)
-            '${field.type.getDisplayString(withNullability: true)} ${field.name},',
-          if (includeFieldValues) 'FieldValue ${field.name}FieldValue,',
+          if (includeFields) 'Object? ${field.name} = _sentinel,',
+          if (includeFieldValues) 'FieldValue? ${field.name}FieldValue,',
         ],
     ].join('\n');
   }
@@ -103,7 +102,7 @@ class _\$${data.documentReferenceName}
           '''
         if (${field.name}FieldValue != null)
           ${field.field}: ${field.name}FieldValue ,
-        '''
+        ''',
       ],
     ].join('\n');
   }
@@ -131,8 +130,8 @@ class _\$${data.documentReferenceName}
 ///
 /// If [SetOptions] are provided, the data can be merged into an existing
 /// document instead of overwriting.
-Future<void> set({
-  $type model,
+Future<void> set(
+  $type model, {
   SetOptions? setOptions,
   $parameters
 });
@@ -164,17 +163,22 @@ void batchSet(
 
     final type = data.type.getDisplayString(withNullability: true);
     final parameters = _parameters(data, includeFields: false);
-    final json = _json(data, includeFields: false);
+    final fieldValuesJson = _json(data, includeFields: false);
+    final json = '''
+{
+  ...${data.toJson('model')},
+  $fieldValuesJson
+}''';
 
     return '''
-Future<void> set({
-  $type model,
+Future<void> set(
+  $type model, {
   SetOptions? setOptions,
   $parameters
 }) async {
-  final json = {$json};
+  final json = $json;
 
-  return reference.set(json);
+  return (reference as DocumentReference).set(json);
 }
 
 void transactionSet(
@@ -182,7 +186,7 @@ void transactionSet(
   $type model, {
   $parameters
 }) {
-  final json = {$json};
+  final json = $json;
 
   transaction.set(reference, json);
 }
@@ -192,7 +196,7 @@ void batchSet(
   $type model, {
   $parameters
 }) {
-  final json = {$json)};
+  final json = $json;
 
   batch.set(reference, json);
 }

--- a/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
+++ b/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
@@ -143,6 +143,9 @@ class _\$${data.documentReferenceName}
 ///
 /// If [SetOptions] are provided, the data can be merged into an existing
 /// document instead of overwriting.
+/// 
+/// Any [FieldValue]s provided will replace the corresponding fields in the
+/// model during serialization.
 Future<void> set(
   $type model, {
   SetOptions? setOptions,
@@ -153,6 +156,9 @@ Future<void> set(
 ///
 /// If the document does not exist yet, it will be created. If you pass
 /// [SetOptions], the provided data can be merged into the existing document.
+/// 
+/// Any [FieldValue]s provided will replace the corresponding fields in the
+/// model during serialization.
 void transactionSet(
   Transaction transaction,
   $type model, {
@@ -163,6 +169,9 @@ void transactionSet(
 ///
 /// If the document does not exist yet, it will be created. If you pass
 /// [SetOptions], the provided data can be merged into the existing document.
+/// 
+/// Any [FieldValue]s provided will replace the corresponding fields in the
+/// model during serialization.
 void batchSet(
   WriteBatch batch,
   $type model, {

--- a/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
+++ b/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
@@ -121,7 +121,7 @@ class _\$${data.documentReferenceName}
   String _setPrototype(CollectionData data) {
     if (data.updatableFields.isEmpty) return '';
 
-    final type = data.type.getDisplayString(withNullability: true);
+    final type = data.type.getDisplayString();
     final parameters = _parameters(data, includeFields: false);
 
     return '''
@@ -161,7 +161,7 @@ void batchSet(
   String _set(CollectionData data) {
     if (data.updatableFields.isEmpty) return '';
 
-    final type = data.type.getDisplayString(withNullability: true);
+    final type = data.type.getDisplayString();
     final parameters = _parameters(data, includeFields: false);
     final fieldValuesJson = _json(data, includeFields: false);
     final json = '''

--- a/packages/cloud_firestore_odm_generator/lib/src/templates/query_reference.dart
+++ b/packages/cloud_firestore_odm_generator/lib/src/templates/query_reference.dart
@@ -120,10 +120,10 @@ class ${data.queryReferenceImplName}
   ${field.orderByDoc}
   ${data.queryReferenceInterfaceName} orderBy$titledNamed($positionalFields {
     bool descending = false,
-    ${field.type.getDisplayString(withNullability: true)} startAt,
-    ${field.type.getDisplayString(withNullability: true)} startAfter,
-    ${field.type.getDisplayString(withNullability: true)} endAt,
-    ${field.type.getDisplayString(withNullability: true)} endBefore,
+    ${field.type.getDisplayString()} startAt,
+    ${field.type.getDisplayString()} startAfter,
+    ${field.type.getDisplayString()} endAt,
+    ${field.type.getDisplayString()} endBefore,
     ${data.documentSnapshotName}? startAtDocument,
     ${data.documentSnapshotName}? endAtDocument,
     ${data.documentSnapshotName}? endBeforeDocument,

--- a/packages/cloud_firestore_odm_generator/pubspec.yaml
+++ b/packages/cloud_firestore_odm_generator/pubspec.yaml
@@ -2,7 +2,7 @@ name: cloud_firestore_odm_generator
 description: A code generator for cloud_firestore_odm.
 homepage: https://firebase.flutter.dev/docs/firestore/odm
 repository: https://github.com/firebaseextended/firestoreodm-flutter
-version: 1.0.0-dev.88
+version: 1.0.0-dev.89
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
Adds generated setters with field value parameters

```dart
  /// Sets data on the document, overwriting any existing data. If the document
  /// does not yet exist, it will be created.
  ///
  /// If [SetOptions] are provided, the data can be merged into an existing
  /// document instead of overwriting.
  ///
  /// Any [FieldValue]s provided will replace the corresponding fields in the
  /// [model] during serialization.
  Future<void> set(
    IgnoredGetter model, {
    SetOptions? options,
    FieldValue valueFieldValue,
  });

  /// Writes to the document using the transaction API.
  ///
  /// If the document does not exist yet, it will be created. If you pass
  /// [SetOptions], the provided data can be merged into the existing document.
  ///
  /// Any [FieldValue]s provided will replace the corresponding fields in the
  /// [model] during serialization.
  void transactionSet(
    Transaction transaction,
    IgnoredGetter model, {
    SetOptions? options,
    FieldValue valueFieldValue,
  });

  /// Writes to the document using the batch API.
  ///
  /// If the document does not exist yet, it will be created. If you pass
  /// [SetOptions], the provided data can be merged into the existing document.
  ///
  /// Any [FieldValue]s provided will replace the corresponding fields in the
  /// [model] during serialization.
  void batchSet(
    WriteBatch batch,
    IgnoredGetter model, {
    SetOptions? options,
    FieldValue valueFieldValue,
  });
```

Note that this is a BREAKING change since I had to modify the signature of the set methods. Also the set methods no longer exist on `FirestoreDocumentReference`.

I also cleaned up some deprecations. If you want those in a separate PR please let me know.

Closes https://github.com/FirebaseExtended/firestoreodm-flutter/issues/5

Also note I did not do this for the `CollectionReference.add` method as that would require a lot of refactoring