### PR TITLE
batchSet and transactionSet should rely on castedReference like set

### DIFF
--- a/packages/cloud_firestore_odm/example/lib/integration.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration.g.dart
@@ -272,7 +272,12 @@ class _$AdvancedJsonDocumentReference extends FirestoreDocumentReference<
         _$AdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    transaction.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    transaction.set(castedReference, json, options);
   }
 
   void batchSet(
@@ -290,7 +295,12 @@ class _$AdvancedJsonDocumentReference extends FirestoreDocumentReference<
         _$AdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    batch.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    batch.set(castedReference, json, options);
   }
 
   Future<void> update({
@@ -1406,7 +1416,12 @@ class _$_PrivateAdvancedJsonDocumentReference
         _$PrivateAdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    transaction.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    transaction.set(castedReference, json, options);
   }
 
   void batchSet(
@@ -1424,7 +1439,12 @@ class _$_PrivateAdvancedJsonDocumentReference
         _$PrivateAdvancedJsonFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    batch.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    batch.set(castedReference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/enums.g.dart
@@ -312,7 +312,12 @@ class _$EnumsDocumentReference
         _$EnumsFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
     };
 
-    transaction.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    transaction.set(castedReference, json, options);
   }
 
   void batchSet(
@@ -338,7 +343,12 @@ class _$EnumsDocumentReference
         _$EnumsFieldMap['nullableEnumList']!: nullableEnumListFieldValue,
     };
 
-    batch.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    batch.set(castedReference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/freezed.g.dart
@@ -269,7 +269,12 @@ class _$PersonDocumentReference
         _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    transaction.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    transaction.set(castedReference, json, options);
   }
 
   void batchSet(
@@ -287,7 +292,12 @@ class _$PersonDocumentReference
         _$$PersonImplFieldMap['lastName']!: lastNameFieldValue,
     };
 
-    batch.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    batch.set(castedReference, json, options);
   }
 
   Future<void> update({
@@ -1372,7 +1382,12 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
         _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
     };
 
-    transaction.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    transaction.set(castedReference, json, options);
   }
 
   void batchSet(
@@ -1387,7 +1402,12 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
         _$$PublicRedirected2ImplFieldMap['value']!: valueFieldValue,
     };
 
-    batch.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    batch.set(castedReference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/named_query.g.dart
@@ -273,7 +273,12 @@ class _$ConflictDocumentReference
         _$ConflictFieldMap['number']!: numberFieldValue,
     };
 
-    transaction.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    transaction.set(castedReference, json, options);
   }
 
   void batchSet(
@@ -288,7 +293,12 @@ class _$ConflictDocumentReference
         _$ConflictFieldMap['number']!: numberFieldValue,
     };
 
-    batch.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    batch.set(castedReference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/integration/query.g.dart
@@ -260,7 +260,12 @@ class _$DurationQueryDocumentReference extends FirestoreDocumentReference<
         _$DurationQueryFieldMap['duration']!: durationFieldValue,
     };
 
-    transaction.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    transaction.set(castedReference, json, options);
   }
 
   void batchSet(
@@ -275,7 +280,12 @@ class _$DurationQueryDocumentReference extends FirestoreDocumentReference<
         _$DurationQueryFieldMap['duration']!: durationFieldValue,
     };
 
-    batch.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    batch.set(castedReference, json, options);
   }
 
   Future<void> update({
@@ -1190,7 +1200,12 @@ class _$DateTimeQueryDocumentReference extends FirestoreDocumentReference<
         _$DateTimeQueryFieldMap['time']!: timeFieldValue,
     };
 
-    transaction.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    transaction.set(castedReference, json, options);
   }
 
   void batchSet(
@@ -1205,7 +1220,12 @@ class _$DateTimeQueryDocumentReference extends FirestoreDocumentReference<
         _$DateTimeQueryFieldMap['time']!: timeFieldValue,
     };
 
-    batch.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    batch.set(castedReference, json, options);
   }
 
   Future<void> update({
@@ -2122,7 +2142,12 @@ class _$TimestampQueryDocumentReference extends FirestoreDocumentReference<
         _$TimestampQueryFieldMap['time']!: timeFieldValue,
     };
 
-    transaction.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    transaction.set(castedReference, json, options);
   }
 
   void batchSet(
@@ -2137,7 +2162,12 @@ class _$TimestampQueryDocumentReference extends FirestoreDocumentReference<
         _$TimestampQueryFieldMap['time']!: timeFieldValue,
     };
 
-    batch.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    batch.set(castedReference, json, options);
   }
 
   Future<void> update({
@@ -3055,7 +3085,12 @@ class _$GeoPointQueryDocumentReference extends FirestoreDocumentReference<
         _$GeoPointQueryFieldMap['point']!: pointFieldValue,
     };
 
-    transaction.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    transaction.set(castedReference, json, options);
   }
 
   void batchSet(
@@ -3070,7 +3105,12 @@ class _$GeoPointQueryDocumentReference extends FirestoreDocumentReference<
         _$GeoPointQueryFieldMap['point']!: pointFieldValue,
     };
 
-    batch.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    batch.set(castedReference, json, options);
   }
 
   Future<void> update({
@@ -3995,7 +4035,12 @@ class _$DocumentReferenceQueryDocumentReference
         _$DocumentReferenceQueryFieldMap['ref']!: refFieldValue,
     };
 
-    transaction.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    transaction.set(castedReference, json, options);
   }
 
   void batchSet(
@@ -4010,7 +4055,12 @@ class _$DocumentReferenceQueryDocumentReference
         _$DocumentReferenceQueryFieldMap['ref']!: refFieldValue,
     };
 
-    batch.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    batch.set(castedReference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/movie.g.dart
+++ b/packages/cloud_firestore_odm/example/lib/movie.g.dart
@@ -355,7 +355,12 @@ class _$MovieDocumentReference
       if (tagsFieldValue != null) _$MovieFieldMap['tags']!: tagsFieldValue,
     };
 
-    transaction.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    transaction.set(castedReference, json, options);
   }
 
   void batchSet(
@@ -385,7 +390,12 @@ class _$MovieDocumentReference
       if (tagsFieldValue != null) _$MovieFieldMap['tags']!: tagsFieldValue,
     };
 
-    batch.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    batch.set(castedReference, json, options);
   }
 
   Future<void> update({
@@ -2514,7 +2524,12 @@ class _$CommentDocumentReference
         _$CommentFieldMap['message']!: messageFieldValue,
     };
 
-    transaction.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    transaction.set(castedReference, json, options);
   }
 
   void batchSet(
@@ -2532,7 +2547,12 @@ class _$CommentDocumentReference
         _$CommentFieldMap['message']!: messageFieldValue,
     };
 
-    batch.set(reference, json, options);
+    final castedReference = reference.withConverter<Map<String, dynamic>>(
+      fromFirestore: (snapshot, options) => throw UnimplementedError(),
+      toFirestore: (value, options) => value,
+    );
+
+    batch.set(castedReference, json, options);
   }
 
   Future<void> update({

--- a/packages/cloud_firestore_odm/example/lib/movie_item.dart
+++ b/packages/cloud_firestore_odm/example/lib/movie_item.dart
@@ -149,16 +149,16 @@ class _LikesState extends State<Likes> {
       // count on the server.
       final newLikes = await FirebaseFirestore.instance
           .runTransaction<int>((transaction) async {
-        final movie = await transaction.get<Movie>(widget.reference.reference);
+        final movie = await widget.reference.transactionGet(transaction);
 
         if (!movie.exists) {
           throw Exception('Document does not exist!');
         }
 
-        final updatedLikes = movie.data()!.likes + 1;
-        transaction.update(
-          widget.reference.reference,
-          <String, Object?>{'likes': updatedLikes},
+        final updatedLikes = movie.data!.likes + 1;
+        widget.reference.transactionUpdate(
+          transaction,
+          likes: updatedLikes,
         );
         return updatedLikes;
       });

--- a/packages/cloud_firestore_odm/example/lib/movies_screen.dart
+++ b/packages/cloud_firestore_odm/example/lib/movies_screen.dart
@@ -169,7 +169,7 @@ class _FilmListState extends State<FilmList> {
     final batch = FirebaseFirestore.instance.batch();
 
     for (final movie in movies.docs) {
-      batch.update(movie.reference.reference, <String, Object?>{'likes': 0});
+      movie.reference.batchUpdate(batch, likes: 0);
     }
     await batch.commit();
   }

--- a/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
+++ b/packages/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
@@ -221,8 +221,13 @@ void transactionSet(
   $parameters
 }) {
   final json = $json;
+  
+  final castedReference = reference.withConverter<Map<String, dynamic>>(
+    fromFirestore: (snapshot, options) => throw UnimplementedError(),
+    toFirestore: (value, options) => value,
+  );
 
-  transaction.set(reference, json, options);
+  transaction.set(castedReference, json, options);
 }
 
 void batchSet(
@@ -233,7 +238,12 @@ void batchSet(
 }) {
   final json = $json;
 
-  batch.set(reference, json, options);
+  final castedReference = reference.withConverter<Map<String, dynamic>>(
+    fromFirestore: (snapshot, options) => throw UnimplementedError(),
+    toFirestore: (value, options) => value,
+  );
+
+  batch.set(castedReference, json, options);
 }
 ''';
   }


### PR DESCRIPTION
Fixes #37

In generated code,  relying on `batch.set(reference, json, options);` for `batchSet`  implementation is wrong because we pass a `DocumentReference<T>` with T a mapping class as a reference with a json data. Cloud_firestore then try to apply the converter but data is already in json. See `write_batch.dart` from cloud_firestore, line 56.

```dart
batch.set(reference, json, options);
``` 
Should be replaced with :
```dart
    final castedReference = reference.withConverter<Map<String, dynamic>>(
      fromFirestore: (snapshot, options) => throw UnimplementedError(),
      toFirestore: (value, options) => value,
    );

    batch.set(castedReference, json, options);
```
Like it's done for set method. Same for transaction.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR